### PR TITLE
Relocate modules used only for tests out of public API.

### DIFF
--- a/cardano-coin-selection.cabal
+++ b/cardano-coin-selection.cabal
@@ -59,7 +59,6 @@ library
       Cardano.CoinSelection.Random
       Cardano.Fee
       Cardano.Types
-      Cardano.Unsafe
       Data.Quantity
       Data.Vector.Shuffle
 
@@ -107,3 +106,4 @@ test-suite unit
       Cardano.FeeSpec
       Cardano.TypesSpec
       Data.Vector.ShuffleSpec
+      Test.Unsafe

--- a/cardano-coin-selection.cabal
+++ b/cardano-coin-selection.cabal
@@ -49,7 +49,6 @@ library
     , random
     , text
     , transformers
-    , vector
   hs-source-dirs:
       src
   exposed-modules:
@@ -60,7 +59,6 @@ library
       Cardano.Fee
       Cardano.Types
       Data.Quantity
-      Data.Vector.Shuffle
 
 test-suite unit
   default-language:
@@ -105,5 +103,6 @@ test-suite unit
       Cardano.CoinSelectionSpec
       Cardano.FeeSpec
       Cardano.TypesSpec
-      Data.Vector.ShuffleSpec
       Test.Unsafe
+      Test.Vector.Shuffle
+      Test.Vector.ShuffleSpec

--- a/test/Cardano/CoinSelectionSpec.hs
+++ b/test/Cardano/CoinSelectionSpec.hs
@@ -41,8 +41,6 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
     ( catMaybes )
-import Data.Vector.Shuffle
-    ( shuffle )
 import Data.Word
     ( Word64, Word8 )
 import Fmt
@@ -65,6 +63,8 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Monadic
     ( monadicIO )
+import Test.Vector.Shuffle
+    ( shuffle )
 
 import qualified Data.ByteString as BS
 import qualified Data.List.NonEmpty as NE

--- a/test/Cardano/TypesSpec.hs
+++ b/test/Cardano/TypesSpec.hs
@@ -27,8 +27,6 @@ import Cardano.Types
     , restrictedBy
     , restrictedTo
     )
-import Cardano.Unsafe
-    ( unsafeFromHex )
 import Data.Set
     ( Set, (\\) )
 import Test.Hspec
@@ -45,6 +43,8 @@ import Test.QuickCheck
     , vectorOf
     , (===)
     )
+import Test.Unsafe
+    ( unsafeFromHex )
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set

--- a/test/Test/Unsafe.hs
+++ b/test/Test/Unsafe.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Cardano.Unsafe
+module Test.Unsafe
     ( unsafeFromHex
     ) where
 

--- a/test/Test/Vector/Shuffle.hs
+++ b/test/Test/Vector/Shuffle.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Data.Vector.Shuffle
+module Test.Vector.Shuffle
     ( -- * Simple
       shuffle
 

--- a/test/Test/Vector/ShuffleSpec.hs
+++ b/test/Test/Vector/ShuffleSpec.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE TypeApplications #-}
 
-module Data.Vector.ShuffleSpec
+module Test.Vector.ShuffleSpec
     ( spec
     ) where
 
 import Prelude
 
-import Data.Vector.Shuffle
-    ( mkSeed, shuffle, shuffleWith )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
@@ -25,6 +23,8 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor, pick, run )
+import Test.Vector.Shuffle
+    ( mkSeed, shuffle, shuffleWith )
 
 import qualified Data.List as L
 import qualified Data.Text as T


### PR DESCRIPTION
## Related Issue

https://github.com/input-output-hk/cardano-wallet/issues/1380

## Summary

This PR moves modules used only for testing out of the public API:

- [x] `Cardano.Unsafe` → `Test.Unsafe`.
- [x] `Data.Vector.Shuffle` → `Test.Vector.Shuffle`.
- [x] `Data.Vector.ShuffleSpec` → `Test.Vector.ShuffleSpec`.