### PR TITLE
Miscellaneous improvements to code readability.

### DIFF
--- a/src/Cardano/CoinSelection.hs
+++ b/src/Cardano/CoinSelection.hs
@@ -6,12 +6,9 @@
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
 --
--- Provides the API of Coin Selection algorithm and Fee Calculation
--- This module contains the implementation of adjusting coin selection for a
--- fee.  The sender pays for the fee and additional inputs are picked randomly.
--- For more information refer to:
--- https://iohk.io/blog/self-organisation-in-coin-selection/
-
+-- Provides general functions and types relating to coin selection and fee
+-- balancing.
+--
 module Cardano.CoinSelection
     (
       -- * Coin Selection
@@ -43,17 +40,21 @@ import GHC.Generics
 
 data CoinSelection = CoinSelection
     { inputs  :: [(TxIn, TxOut)]
-      -- ^ Picked inputs
+      -- ^ Picked inputs.
     , outputs :: [TxOut]
-      -- ^ Picked outputs
+      -- ^ Picked outputs.
     , change  :: [Coin]
-      -- ^ Resulting changes
+      -- ^ Resulting change.
     } deriving (Generic, Show, Eq)
 
--- NOTE
+-- NOTE:
+--
 -- We don't check for duplicates when combining selections because we assume
--- they are constructed from independent elements. In practice, we could nub
--- the list or use a `Set` ?
+-- they are constructed from independent elements.
+--
+-- As an alternative to the current implementation, we could 'nub' the list or
+-- use a 'Set'.
+--
 instance Semigroup CoinSelection where
     a <> b = CoinSelection
         { inputs = inputs a <> inputs b
@@ -75,21 +76,23 @@ instance Buildable CoinSelection where
 data CoinSelectionOptions e = CoinSelectionOptions
     { maximumNumberOfInputs
         :: Word8 -> Word8
-            -- ^ Maximum number of inputs allowed for a given number of outputs
+            -- ^ Calculate the maximum number of inputs allowed for a given
+            -- number of outputs.
     , validate
         :: CoinSelection -> Either e ()
-            -- ^ Returns any backend-specific error regarding coin selection
+            -- ^ Validate the given coin selection, returning a backend-specific
+            -- error.
     } deriving (Generic)
 
--- | Calculate the sum of all input values
+-- | Calculate the sum of all input values.
 inputBalance :: CoinSelection -> Word64
 inputBalance =  foldl' (\total -> addTxOut total . snd) 0 . inputs
 
--- | Calculate the sum of all output values
+-- | Calculate the sum of all output values.
 outputBalance :: CoinSelection -> Word64
 outputBalance = foldl' addTxOut 0 . outputs
 
--- | Calculate the sum of all output values
+-- | Calculate the sum of all output values.
 changeBalance :: CoinSelection -> Word64
 changeBalance = foldl' addCoin 0 . change
 
@@ -104,23 +107,30 @@ addCoin total c = total + (fromIntegral (getCoin c))
 
 data ErrCoinSelection e
     = ErrNotEnoughMoney Word64 Word64
-    -- ^ UTxO exhausted during input selection
-    -- We record the balance of the UTxO as well as the size of the payment we
+    -- ^ The UTxO was exhausted during input selection.
+    --
+    -- Records the balance of the UTxO, as well as the size of the payment we
     -- tried to make.
+    --
     | ErrUtxoNotEnoughFragmented Word64 Word64
-    -- ^ UTxO is not enough fragmented for the number of transaction outputs
-    -- We record the number of UTxO entries as well as the number of the
-    -- outputs of the transaction.
+    -- ^ The UTxO was not fragmented enough to support the required number of
+    -- transaction outputs.
+    --
+    -- Records the number of UTxO entries, as well as the number of the
+    -- transaction outputs.
+    --
     | ErrMaximumInputsReached Word64
-    -- ^ When trying to construct a transaction, the max number of allowed
-    -- inputs was reached.
+    -- ^ The maximum number of allowed inputs was not enough to cover the total
+    -- payment amount.
+    --
     | ErrInputsDepleted
-    -- ^ When trying to construct a transaction, the available inputs are
-    -- depleted even when UTxO is properly fragmented and with enough funds to
-    -- cover payment
+    -- ^ All available inputs were depleted, even though the UTxO was
+    -- sufficiently fragmented and with enough funds to cover payment.
+    --
     | ErrInvalidSelection e
-    -- ^ Somewhat, we ended up generating an invalid coin selection because of
-    -- inputs passed down to the coin selection function, or because a target
-    -- backend has extra-limitations not covered by our coin selection
-    -- algorithm.
+    -- ^ The generated coin selection was reported to be invalid by the backend.
+    --
+    -- Records the backend-specific error that occurred while attempting to
+    -- validate the selection.
+    --
     deriving (Show, Eq)

--- a/src/Cardano/CoinSelection.hs
+++ b/src/Cardano/CoinSelection.hs
@@ -112,7 +112,7 @@ data ErrCoinSelection e
     -- Records the balance of the UTxO, as well as the size of the payment we
     -- tried to make.
     --
-    | ErrUtxoNotEnoughFragmented Word64 Word64
+    | ErrUtxoNotFragmentedEnough Word64 Word64
     -- ^ The UTxO was not fragmented enough to support the required number of
     -- transaction outputs.
     --

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -42,7 +42,7 @@ largestFirst
     -> UTxO
     -> ExceptT (ErrCoinSelection e) m (CoinSelection, UTxO)
 largestFirst opt outs utxo = do
-    let descending = NE.toList . NE.sortBy (flip $ comparing coin)
+    let outsDescending = NE.toList $ NE.sortBy (flip $ comparing coin) outs
     let nOuts = fromIntegral $ NE.length outs
     let maxN = fromIntegral $ maximumNumberOfInputs opt (fromIntegral nOuts)
     let nLargest = take maxN
@@ -51,11 +51,11 @@ largestFirst opt outs utxo = do
             . getUTxO
     let guard = except . left ErrInvalidSelection . validate opt
 
-    case foldM atLeast (nLargest utxo, mempty) (descending outs) of
+    case foldM atLeast (nLargest utxo, mempty) outsDescending of
         Just (utxo', s) ->
             guard s $> (s, UTxO $ Map.fromList utxo')
         Nothing -> do
-            let moneyRequested = sum $ (getCoin . coin) <$> (descending outs)
+            let moneyRequested = sum $ (getCoin . coin) <$> outsDescending
             let utxoBalance = fromIntegral $ balance utxo
             let nUtxo = fromIntegral $ L.length $ (Map.toList . getUTxO) utxo
 

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -63,7 +63,7 @@ largestFirst opt outs utxo = do
                 $ throwE $ ErrNotEnoughMoney utxoBalance moneyRequested
 
             when (nUtxo < nOuts)
-                $ throwE $ ErrUtxoNotEnoughFragmented nUtxo nOuts
+                $ throwE $ ErrUtxoNotFragmentedEnough nUtxo nOuts
 
             when (fromIntegral maxN > nUtxo)
                 $ throwE ErrInputsDepleted

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -4,9 +4,9 @@
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
 --
--- This module contains the implementation of largestFirst
--- input selection algorithm
-
+-- This module contains an implementation of the __Largest-First__ coin
+-- selection algorithm.
+--
 module Cardano.CoinSelection.LargestFirst (
     largestFirst
   ) where
@@ -34,7 +34,7 @@ import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 
--- | Largest-first input selection policy
+-- | Implements the __Largest-First__ coin selection algorithm.
 largestFirst
     :: forall m e. Monad m
     => CoinSelectionOptions e
@@ -70,10 +70,11 @@ largestFirst opt outs utxo = do
 
             throwE $ ErrMaximumInputsReached (fromIntegral maxN)
 
--- Selecting coins to cover at least the specified value
--- The details of the algorithm are following:
+-- Selects coins to cover at least the specified value.
 --
--- (a) transaction outputs are processed starting from the largest one
+-- The details of the algorithm are as follows:
+--
+-- (a) transaction outputs are processed starting from the largest first.
 --
 -- (b) `maximumNumberOfInputs` biggest available UTxO inputs are taken into
 --     consideration. They constitute a candidate UTxO inputs from which coin

--- a/src/Cardano/Types.hs
+++ b/src/Cardano/Types.hs
@@ -212,7 +212,7 @@ pickRandom (UTxO utxo)
         ix <- fromEnum <$> generateBetween 0 (toEnum (Map.size utxo - 1))
         return (Just $ Map.elemAt ix utxo, UTxO $ Map.deleteAt ix utxo)
 
--- | Compute the balance of a UTxO
+-- | Compute the balance of a UTxO.
 balance :: UTxO -> Natural
 balance =
     Map.foldl' fn 0 . getUTxO
@@ -220,7 +220,7 @@ balance =
     fn :: Natural -> TxOut -> Natural
     fn tot out = tot + fromIntegral (getCoin (coin out))
 
--- | Compute the balance of a unwrapped UTxO
+-- | Compute the balance of a unwrapped UTxO.
 balance' :: [(TxIn, TxOut)] -> Word64
 balance' =
     fromIntegral . balance . UTxO . Map.fromList
@@ -250,10 +250,10 @@ restrictedTo (UTxO utxo) outs =
 -------------------------------------------------------------------------------}
 
 -- | Allows us to define the "domain" of any type — @UTxO@ in particular — and
--- use 'dom' to refer to the /inputs/ of an /utxo/.
+-- use 'dom' to refer to the /inputs/ of an /UTxO/.
 --
--- This is the terminology used in the [Formal Specification for a Cardano](https://github.com/input-output-hk/cardano-wallet/blob/master/specifications/wallet/formal-specification-for-a-cardano-wallet.pdf)
--- uses.
+-- This is the terminology used in the [Formal Specification for a Cardano
+-- Wallet](https://github.com/input-output-hk/cardano-wallet/blob/master/specifications/wallet/formal-specification-for-a-cardano-wallet.pdf).
 class Dom a where
     type DomElem a :: Type
     dom :: a -> Set (DomElem a)

--- a/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -132,7 +132,7 @@ spec = do
 
         coinSelectionUnitTest largestFirst
             "enough coins, but not fragmented enough"
-            (Left $ ErrUtxoNotEnoughFragmented 3 4)
+            (Left $ ErrUtxoNotFragmentedEnough 3 4)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation

--- a/test/Cardano/CoinSelection/RandomSpec.hs
+++ b/test/Cardano/CoinSelection/RandomSpec.hs
@@ -209,7 +209,7 @@ spec = do
                 })
 
         coinSelectionUnitTest random ""
-            (Left $ ErrUtxoNotEnoughFragmented 3 4)
+            (Left $ ErrUtxoNotFragmentedEnough 3 4)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation

--- a/test/Cardano/CoinSelectionSpec.hs
+++ b/test/Cardano/CoinSelectionSpec.hs
@@ -17,10 +17,10 @@ module Cardano.CoinSelectionSpec
     , alwaysFail
     ) where
 
--- | This module contains shared logic between the coin selection tests. They
--- ought to share the same interface, and therefore, it makes sense for them to
--- also require the same arbitrary instances and instrument testing in a similar
--- way for both.
+-- | This module contains shared functionality for coin selection tests.
+--
+-- Coin selection algorithms share a common interface, and therefore it makes
+-- sense for them to also share arbitrary instances and tests.
 
 import Prelude
 
@@ -128,15 +128,15 @@ data CoinSelectionFixture = CoinSelectionFixture
 -- | A dummy error for testing extra validation
 data ErrValidation = ErrValidation deriving (Eq, Show)
 
--- | Smart constructor for the validation function that always succeed
+-- | Smart constructor for the validation function that always succeeds.
 noValidation :: CoinSelection -> Either ErrValidation ()
 noValidation = const (Right ())
 
--- | Smart constructor for the validation function that always fail
+-- | Smart constructor for the validation function that always fails.
 alwaysFail :: CoinSelection -> Either ErrValidation ()
 alwaysFail = const (Left ErrValidation)
 
--- | Testing-friendly format for 'CoinSelection' results of unit tests
+-- | Testing-friendly format for 'CoinSelection' results of unit tests.
 data CoinSelectionResult = CoinSelectionResult
     { rsInputs :: [Word64]
     , rsChange :: [Word64]
@@ -144,7 +144,7 @@ data CoinSelectionResult = CoinSelectionResult
     } deriving (Eq, Show)
 
 -- | Generate a 'UTxO' and 'TxOut' matching the given 'Fixture', and perform
--- given coin selection on it.
+-- the given coin selection on it.
 coinSelectionUnitTest
     :: ( CoinSelectionOptions ErrValidation
          -> NonEmpty TxOut


### PR DESCRIPTION
## Related Issue

https://github.com/input-output-hk/cardano-wallet/issues/1382

## Summary

- [x] Makes documentation compatible with Haddock syntax, where applicable.
- [x] Corrects grammar errors in error constructors.
- [x] Clarifies the documentation of error value constructors for `ErrCoinSelection`.
- [x] Fixes a few small other grammatical oversights in documentation.
- [x] Restructures function `atLeast` for added clarity:
    - [x] Uses pattern matching on inputs, removing the need for partial functions.
    - [x] Adds comments to clarify the purpose of each case within the `coverTarget`.
    - [x] Uses clearer names for accumulators to reflect their purpose.