### PR TITLE
Improve documentation for largest-first algorithm.

### DIFF
--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -66,7 +66,7 @@ import qualified Data.Map.Strict as Map
 -- For /each output/ in the (descending) output list, the algorithm repeatedly
 -- selects unspent values from the /remaining UTxO set/ (in descending order)
 -- until the /total selected value/ is greater than (or equal to) the output
--- value, at which point the algorithm move ons to processing the /next/
+-- value, at which point the algorithm moves on to processing the /next/
 -- output.
 --
 -- If the /total selected value/ is greater than required for a particular

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -99,23 +99,26 @@ import qualified Data.Map.Strict as Map
 --
 --  *   /Step 2/
 --
---      Repeatedly remove entries from the head of the /remaining UTxO list/
---      until the total value of entries removed is /greater than or equal to/
---      the value of the /unpaid output/.
+--      Repeatedly remove UTxO entries from the head of the
+--      /remaining UTxO list/ until the total value of entries removed is
+--      /greater than or equal to/ the value of the /removed output/.
 --
 --  *   /Step 3/
 --
---      Use the /removed UTxO entries/ to pay for the /unpaid output/.
+--      Use the /removed UTxO entries/ to pay for the /removed output/.
 --
---      This is achieved by adding the /removed UTxO entries/ to the 'inputs'
---      field of the /accumulated coin selection/, and adding the /output/ to
---      the 'outputs' field of the /accumulated coin selection/.
+--      This is achieved by:
+--
+--      *  adding the /removed UTxO entries/ to the 'inputs' field of the
+--         /accumulated coin selection/.
+--      *  adding the /removed output/ to the 'outputs' field of the
+--         /accumulated coin selection/.
 --
 --  *   /Step 4/
 --
---      If the /total selected value/ is greater than the value required for
---      the current output, generate a coin whose value is equal to the exact
---      difference, and add it to the 'change' field of the
+--      If the /total value/ of the /removed UTxO entries/ is greater than the
+--      value of the /removed output/, generate a coin whose value is equal to
+--      the exact difference, and add it to the 'change' field of the
 --      /accumulated coin selection/.
 --
 --  *   /Step 5/

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -9,6 +9,7 @@
 --
 module Cardano.CoinSelection.LargestFirst (
     largestFirst
+  , atLeast
   ) where
 
 import Prelude
@@ -144,27 +145,16 @@ largestFirst options outputsRequested utxo =
     validateSelection =
         except . left ErrInvalidSelection . validate options
 
--- Selects coins to cover at least the specified value.
+-- | Attempts to pay for a /single transaction output/ by selecting the
+--   /smallest possible/ number of entries from the /head/ of the given
+--   UTxO list.
 --
--- The details of the algorithm are as follows:
+-- Returns a /reduced/ list of UTxO entries, and a coin selection that is
+-- /updated/ to include the payment.
 --
--- (a) transaction outputs are processed starting from the largest first.
+-- If the total value of entries in the given UTxO list is /less than/ the
+-- required output amount, this function will return 'Nothing'.
 --
--- (b) `maximumNumberOfInputs` biggest available UTxO inputs are taken into
---     consideration. They constitute a candidate UTxO inputs from which coin
---     selection will be tried. Each output is treated independently with the
---     heuristic described in (c).
---
--- (c) the biggest candidate UTxO input is tried first to cover the transaction
---     output. If the input is not enough, then the next biggest one is added
---     to check if they can cover the transaction output. This process is
---     continued until the output is covered or the candidates UTxO inputs are
---     depleted.  In the latter case `MaximumInputsReached` error is triggered.
---     If the transaction output is covered the next biggest one is processed.
---     Here, the biggest UTxO input, not participating in the coverage, is
---     taken. We are back at (b) step as a result
---
--- The steps are continued until all transaction are covered.
 atLeast
     :: ([(TxIn, TxOut)], CoinSelection)
     -> TxOut

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -148,8 +148,8 @@ import qualified Data.Map.Strict as Map
 --      See: __'ErrUtxoNotFragmentedEnough'__.
 --
 --  3.  Due to the particular /distribution/ of values within the initial UTxO
---      set, the algorithm depletes all entries from the set /before/ it is
---      able to pay for all requested outputs.
+--      set, the algorithm depletes all entries from the UTxO set /before/ it
+--      is able to pay for all requested outputs.
 --
 --      See: __'ErrUxtoFullyDepleted'__.
 --

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -81,7 +81,7 @@ import qualified Data.Map.Strict as Map
 --      /available/) is /less than/ the total value of the output list (the
 --      amount of money /required/).
 --
---      See: __'ErrNotEnoughMoney'__.
+--      See: __'ErrUtxoBalanceInsufficient'__.
 --
 --  2.  The /number/ of entries in the starting UTxO set is /smaller than/ the
 --      number of requested outputs.
@@ -95,12 +95,12 @@ import qualified Data.Map.Strict as Map
 --      set, the algorithm depletes all entries from the set /before/ it is able
 --      to pay for all requested outputs.
 --
---      See: __'ErrInputsDepleted'__.
+--      See: __'ErrUxtoFullyDepleted'__.
 --
 --  4.  The /number/ of UTxO entries needed to pay for the requested outputs
---      would /exceed/ the upper limit specified by 'maximumNumberOfInputs'.
+--      would /exceed/ the upper limit specified by 'maximumInputCount'.
 --
---      See: __'ErrMaximumInputsReached'__.
+--      See: __'ErrMaximumInputCountExceeded'__.
 --
 largestFirst
     :: forall m e. Monad m
@@ -118,19 +118,19 @@ largestFirst options outputsRequested utxo =
   where
     errorCondition
       | amountAvailable < amountRequested =
-          ErrNotEnoughMoney amountAvailable amountRequested
+          ErrUtxoBalanceInsufficient amountAvailable amountRequested
       | utxoCount < outputCount =
           ErrUtxoNotFragmentedEnough utxoCount outputCount
       | utxoCount <= inputCountMax =
-          ErrInputsDepleted
+          ErrUxtoFullyDepleted
       | otherwise =
-          ErrMaximumInputsReached inputCountMax
+          ErrMaximumInputCountExceeded inputCountMax
     amountAvailable =
         fromIntegral $ balance utxo
     amountRequested =
         sum $ (getCoin . coin) <$> outputsRequested
     inputCountMax =
-        fromIntegral $ maximumNumberOfInputs options $ fromIntegral outputCount
+        fromIntegral $ maximumInputCount options $ fromIntegral outputCount
     outputCount =
         fromIntegral $ NE.length outputsRequested
     outputsDescending =

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -41,7 +41,7 @@ import qualified Data.Map.Strict as Map
 --
 -- For the given /output list/ and /initial UTxO set/, this algorithm generates
 -- a /coin selection/ that is capable of paying for all of the outputs, and a
--- /remaining UTxO set/ from which spent values have been removed.
+-- /remaining UTxO set/ from which all spent values have been removed.
 --
 -- === State Maintained by the Algorithm
 --

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -105,14 +105,18 @@ import qualified Data.Map.Strict as Map
 --
 --  *   /Step 3/
 --
---      Use the /removed UTxO entries/ to pay for the /unpaid output/, by
---      adding entries to the /accumulated coin selection/.
+--      Use the /removed UTxO entries/ to pay for the /unpaid output/.
+--
+--      This is achieved by adding the /removed UTxO entries/ to the 'inputs'
+--      field of the /accumulated coin selection/, and adding the /output/ to
+--      the 'outputs' field of the /accumulated coin selection/.
 --
 --  *   /Step 4/
 --
 --      If the /total selected value/ is greater than the value required for
---      the current output, generate a /change output/ with the exact
---      difference in value, and add it to the /accumulated coin selection/.
+--      the current output, generate a coin whose value is equal to the exact
+--      difference, and add it to the 'change' field of the
+--      /accumulated coin selection/.
 --
 --  *   /Step 5/
 --

--- a/src/Cardano/CoinSelection/Migration.hs
+++ b/src/Cardano/CoinSelection/Migration.hs
@@ -174,7 +174,7 @@ idealBatchSize coinselOpts = fixPoint 1
         | otherwise = fixPoint (n + 1)
       where
         maxN :: Word8 -> Word8
-        maxN = maximumNumberOfInputs coinselOpts
+        maxN = maximumInputCount coinselOpts
 
 -- | Safe conversion of an integral type to an integer
 integer :: Integral a => a -> Integer

--- a/src/Cardano/CoinSelection/Random.hs
+++ b/src/Cardano/CoinSelection/Random.hs
@@ -115,7 +115,7 @@ random
 random opt outs utxo = do
     let descending = NE.toList . NE.sortBy (flip $ comparing coin)
     let nOuts = fromIntegral $ NE.length outs
-    let maxN = fromIntegral $ maximumNumberOfInputs opt nOuts
+    let maxN = fromIntegral $ maximumInputCount opt nOuts
     randomMaybe <- lift $ runMaybeT $
         foldM makeSelection (maxN, utxo, []) (descending outs)
     case randomMaybe of

--- a/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -45,7 +45,8 @@ import qualified Data.Set as Set
 
 spec :: Spec
 spec = do
-    describe "Coin selection : LargestFirst algorithm unit tests" $ do
+    describe "Coin selection: largest-first algorithm: unit tests" $ do
+
         coinSelectionUnitTest largestFirst ""
             (Right $ CoinSelectionResult
                 { rsInputs = [17]
@@ -111,7 +112,8 @@ spec = do
                 , txOutputs = 11 :| [1]
                 })
 
-        coinSelectionUnitTest largestFirst "not enough coins"
+        coinSelectionUnitTest largestFirst
+            "UTxO balance not sufficient"
             (Left $ ErrUtxoBalanceInsufficient 39 40)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -121,7 +123,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "not enough coin & not fragmented enough"
+            "UTxO balance not sufficient, and not fragmented enough"
             (Left $ ErrUtxoBalanceInsufficient 39 43)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -131,7 +133,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "enough coins, but not fragmented enough"
+            "UTxO balance sufficient, but not fragmented enough"
             (Left $ ErrUtxoNotFragmentedEnough 3 4)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -141,8 +143,8 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "enough coins, fragmented enough, but one output depletes all \
-            \inputs"
+            "UTxO balance sufficient, fragmented enough, but single output \
+            \depletes all UTxO entries"
             (Left ErrUxtoFullyDepleted)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -151,10 +153,9 @@ spec = do
                 , txOutputs = 40 :| [1]
                 })
 
-        coinSelectionUnitTest
-            largestFirst
-            "enough coins, fragmented enough, but the input needed to stay \
-            \for the next output is depleted"
+        coinSelectionUnitTest largestFirst
+            "UTxO balance sufficient, fragmented enough, but single output \
+            \depletes all UTxO entries"
             (Left ErrUxtoFullyDepleted)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -163,7 +164,9 @@ spec = do
                 , txOutputs = 41 :| [6]
                 })
 
-        coinSelectionUnitTest largestFirst "each output needs <maxNumOfInputs"
+        coinSelectionUnitTest largestFirst
+            "UTxO balance sufficient, fragmented enough, but maximum input \
+            \count exceeded"
             (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
@@ -172,7 +175,9 @@ spec = do
                 , txOutputs = NE.fromList (replicate 100 1)
                 })
 
-        coinSelectionUnitTest largestFirst "each output needs >maxNumInputs"
+        coinSelectionUnitTest largestFirst
+            "UTxO balance sufficient, fragmented enough, but maximum input \
+            \count exceeded"
             (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
@@ -182,7 +187,8 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "enough coins but, strict maximumInputCount"
+            "UTxO balance sufficient, fragmented enough, but maximum input \
+            \count exceeded"
             (Left $ ErrMaximumInputCountExceeded 2)
             (CoinSelectionFixture
                 { maxNumOfInputs = 2
@@ -191,7 +197,8 @@ spec = do
                 , txOutputs = 11 :| [1]
                 })
 
-        coinSelectionUnitTest largestFirst "custom validation"
+        coinSelectionUnitTest largestFirst
+            "Custom validation test fails"
             (Left $ ErrInvalidSelection ErrValidation)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -200,7 +207,8 @@ spec = do
                 , txOutputs = 2 :| []
                 })
 
-    describe "Coin selection properties : LargestFirst algorithm" $ do
+    describe "Coin selection: largest-first algorithm: properties" $ do
+
         it "forall (UTxO, NonEmpty TxOut), running algorithm twice yields \
             \exactly the same result"
             (property propDeterministic)

--- a/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -112,7 +112,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst "not enough coins"
-            (Left $ ErrNotEnoughMoney 39 40)
+            (Left $ ErrUtxoBalanceInsufficient 39 40)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation
@@ -122,7 +122,7 @@ spec = do
 
         coinSelectionUnitTest largestFirst
             "not enough coin & not fragmented enough"
-            (Left $ ErrNotEnoughMoney 39 43)
+            (Left $ ErrUtxoBalanceInsufficient 39 43)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation
@@ -143,7 +143,7 @@ spec = do
         coinSelectionUnitTest largestFirst
             "enough coins, fragmented enough, but one output depletes all \
             \inputs"
-            (Left ErrInputsDepleted)
+            (Left ErrUxtoFullyDepleted)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation
@@ -155,7 +155,7 @@ spec = do
             largestFirst
             "enough coins, fragmented enough, but the input needed to stay \
             \for the next output is depleted"
-            (Left ErrInputsDepleted)
+            (Left ErrUxtoFullyDepleted)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation
@@ -164,7 +164,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst "each output needs <maxNumOfInputs"
-            (Left $ ErrMaximumInputsReached 9)
+            (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , validateSelection = noValidation
@@ -173,7 +173,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst "each output needs >maxNumInputs"
-            (Left $ ErrMaximumInputsReached 9)
+            (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , validateSelection = noValidation
@@ -182,8 +182,8 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "enough coins but, strict maximumNumberOfInputs"
-            (Left $ ErrMaximumInputsReached 2)
+            "enough coins but, strict maximumInputCount"
+            (Left $ ErrMaximumInputCountExceeded 2)
             (CoinSelectionFixture
                 { maxNumOfInputs = 2
                 , validateSelection = noValidation

--- a/test/Cardano/CoinSelection/RandomSpec.hs
+++ b/test/Cardano/CoinSelection/RandomSpec.hs
@@ -155,7 +155,7 @@ spec = do
 
         coinSelectionUnitTest random
             "enough funds, proper fragmentation, inputs depleted"
-            (Left ErrInputsDepleted)
+            (Left ErrUxtoFullyDepleted)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation
@@ -164,7 +164,7 @@ spec = do
                 })
 
         coinSelectionUnitTest random ""
-            (Left $ ErrMaximumInputsReached 2)
+            (Left $ ErrMaximumInputCountExceeded 2)
             (CoinSelectionFixture
                 { maxNumOfInputs = 2
                 , validateSelection = noValidation
@@ -173,7 +173,7 @@ spec = do
                 })
 
         coinSelectionUnitTest random "each output needs <maxNumOfInputs"
-            (Left $ ErrMaximumInputsReached 9)
+            (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , validateSelection = noValidation
@@ -182,7 +182,7 @@ spec = do
                 })
 
         coinSelectionUnitTest random "each output needs >maxNumInputs"
-            (Left $ ErrMaximumInputsReached 9)
+            (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , validateSelection = noValidation
@@ -191,7 +191,7 @@ spec = do
                 })
 
         coinSelectionUnitTest random ""
-            (Left $ ErrNotEnoughMoney 39 40)
+            (Left $ ErrUtxoBalanceInsufficient 39 40)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation
@@ -200,7 +200,7 @@ spec = do
                 })
 
         coinSelectionUnitTest random ""
-            (Left $ ErrNotEnoughMoney 39 43)
+            (Left $ ErrUtxoBalanceInsufficient 39 43)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation

--- a/test/Cardano/CoinSelectionSpec.hs
+++ b/test/Cardano/CoinSelectionSpec.hs
@@ -170,11 +170,11 @@ coinSelectionUnitTest run lbl expected (CoinSelectionFixture n fn utxoF outsF) =
   where
     title :: String
     title = mempty
+        <> if null lbl then "" else lbl <> ":\n\t"
         <> "max=" <> show n
         <> ", UTxO=" <> show utxoF
         <> ", Output=" <> show (NE.toList outsF)
         <> " --> " <> show (rsInputs <$> expected)
-        <> if null lbl then "" else " (" <> lbl <> ")"
 
     setup :: IO (UTxO, NonEmpty TxOut)
     setup = do


### PR DESCRIPTION
## Related Issue

https://github.com/input-output-hk/cardano-wallet/issues/1382

## Summary

This goal of this PR is to improve the documentation of the largest-first algorithm and the readability of the implementation.

### Documentation Improvements

- [x] Provides Haddock documentation for the `largestFirst` function.
- [x] Revises existing the Haddock documentation for the `atLeast` function.
- [x] Revises existing the Haddock documentation for the `ErrCoinSelection` type.
- [x] Revises descriptions of test fixtures, so that terminology used is consistent with the documentation.

### Related Code Improvements

- [x] Adjusts the names of constructors for `ErrCoinSelection`, so that terminology used is consistent with the documentation.
- [x] Revises function `largestFirst` to:
    - [x] Use a single `where` clause to define all constants rather than a sequence of monadic `let` bindings.
    - [x] Use a pure constant with pattern guard to define the error condition rather than a sequence of monadic `when` clauses.
    - [x] Use names `amountRequested` and `amountAvailable`, making it obvious that these values are _directly comparable_.
    - [x] Use names `outputsDescending` and `utxoDescending`, making it obvious that these values refer to lists in _descending order_.