### PR TITLE
Add documentation to the `CoinSelection` module.

### DIFF
--- a/src/Cardano/CoinSelection.hs
+++ b/src/Cardano/CoinSelection.hs
@@ -77,12 +77,13 @@ instance Monoid CoinSelection where
     mempty = CoinSelection [] [] []
 
 instance Buildable CoinSelection where
-    build (CoinSelection inps outs chngs) = mempty
-        <> nameF "inputs" (blockListF' "-" inpsF inps)
-        <> nameF "outputs" (blockListF outs)
-        <> nameF "change" (listF chngs)
-      where
-        inpsF (txin, txout) = build txin <> " (~ " <> build txout <> ")"
+    build s = mempty
+        <> nameF "inputs"
+            (blockListF' "-" build $ inputs s)
+        <> nameF "outputs"
+            (blockListF $ outputs s)
+        <> nameF "change"
+            (listF $ change s)
 
 -- | Represents a set of options to be passed to a coin selection algorithm.
 --

--- a/src/Cardano/CoinSelection.hs
+++ b/src/Cardano/CoinSelection.hs
@@ -114,12 +114,6 @@ changeBalance = foldl' addCoin 0 . change
 feeBalance :: CoinSelection -> Word64
 feeBalance sel = inputBalance sel - outputBalance sel - changeBalance sel
 
-addTxOut :: Integral a => a -> TxOut -> a
-addTxOut total = addCoin total . coin
-
-addCoin :: Integral a => a -> Coin -> a
-addCoin total c = total + (fromIntegral (getCoin c))
-
 -- | Represents the set of possible failures that can occur when attempting
 --   to produce a 'CoinSelection'.
 --
@@ -155,3 +149,13 @@ data ErrCoinSelection e
     -- validate the selection.
     --
     deriving (Show, Eq)
+
+--------------------------------------------------------------------------------
+-- Utility Functions
+--------------------------------------------------------------------------------
+
+addTxOut :: Integral a => a -> TxOut -> a
+addTxOut total = addCoin total . coin
+
+addCoin :: Integral a => a -> Coin -> a
+addCoin total c = total + (fromIntegral (getCoin c))


### PR DESCRIPTION
## Related Issue

https://github.com/input-output-hk/cardano-wallet/issues/1382

## Summary

This PR:

- [x] adds Haddock documentation to functions and types within the `CoinSelection` module.
- [x] revises the grouping of exported types into logical sections.
- [x] moves utility functions (not part of the public API) to the end of the module.