### PR TITLE
Introduce an abstract `CoinSelectionAlgorithm` type.

### DIFF
--- a/src/Cardano/CoinSelection.hs
+++ b/src/Cardano/CoinSelection.hs
@@ -12,7 +12,8 @@
 module Cardano.CoinSelection
     (
       -- * Types
-      CoinSelection (..)
+      CoinSelectionAlgorithm (..)
+    , CoinSelection (..)
     , CoinSelectionOptions (..)
     , ErrCoinSelection (..)
 
@@ -27,9 +28,13 @@ module Cardano.CoinSelection
 import Prelude
 
 import Cardano.Types
-    ( Coin (..), TxIn, TxOut (..) )
+    ( Coin (..), TxIn, TxOut (..), UTxO (..) )
+import Control.Monad.Trans.Except
+    ( ExceptT (..) )
 import Data.List
     ( foldl' )
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
 import Data.Word
     ( Word64, Word8 )
 import Fmt
@@ -40,6 +45,14 @@ import GHC.Generics
 {-------------------------------------------------------------------------------
                                 Coin Selection
 -------------------------------------------------------------------------------}
+
+newtype CoinSelectionAlgorithm m e = CoinSelectionAlgorithm
+    { selectCoins
+        :: CoinSelectionOptions e
+        -> NonEmpty TxOut
+        -> UTxO
+        -> ExceptT (ErrCoinSelection e) m (CoinSelection, UTxO)
+    }
 
 -- | Represents the result of running a /coin selection algorithm/, which
 --   selects coins from an /initial UTxO set/ in order to cover a given set of

--- a/src/Cardano/CoinSelection.hs
+++ b/src/Cardano/CoinSelection.hs
@@ -46,6 +46,13 @@ import GHC.Generics
                                 Coin Selection
 -------------------------------------------------------------------------------}
 
+-- | Represents a /coin selection algorithm/.
+--
+-- The function 'selectCoins', when applied to the given /output list/ and
+-- /initial UTxO set/, generates a 'CoinSelection' that is capable of paying
+-- for all of the outputs, and a /remaining UTxO set/ from which all spent
+-- values have been removed.
+--
 newtype CoinSelectionAlgorithm m e = CoinSelectionAlgorithm
     { selectCoins
         :: CoinSelectionOptions e
@@ -54,9 +61,9 @@ newtype CoinSelectionAlgorithm m e = CoinSelectionAlgorithm
         -> ExceptT (ErrCoinSelection e) m (CoinSelection, UTxO)
     }
 
--- | Represents the result of running a /coin selection algorithm/, which
---   selects coins from an /initial UTxO set/ in order to cover a given set of
---   /output payments/.
+-- | Represents the result of running a /coin selection algorithm/.
+--
+-- See 'CoinSelectionAlgorithm'.
 --
 data CoinSelection = CoinSelection
     { inputs :: [(TxIn, TxOut)]

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RankNTypes #-}
-
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -162,11 +160,11 @@ import qualified Data.Map.Strict as Map
 --
 --      See: __'ErrMaximumInputCountExceeded'__.
 --
-largestFirst :: forall m e. Monad m => CoinSelectionAlgorithm m e
+largestFirst :: Monad m => CoinSelectionAlgorithm m e
 largestFirst = CoinSelectionAlgorithm payForOutputs
 
 payForOutputs
-    :: forall m e. Monad m
+    :: Monad m
     => CoinSelectionOptions e
     -> NonEmpty TxOut
     -> UTxO

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -40,12 +40,6 @@ import qualified Data.Map.Strict as Map
 
 -- | Generate a coin selection according to the __largest first__ algorithm.
 --
--- === Summary
---
--- For the given /output list/ and /initial UTxO set/, this algorithm generates
--- a /coin selection/ that is capable of paying for all of the outputs, and a
--- /remaining UTxO set/ from which all spent values have been removed.
---
 -- === State Maintained by the Algorithm
 --
 -- At all stages of processing, the algorithm maintains:

--- a/src/Cardano/CoinSelection/Random.hs
+++ b/src/Cardano/CoinSelection/Random.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
 
 -- |
@@ -110,7 +109,7 @@ data TargetRange = TargetRange
 -- that a randomly chosen UTxO entry will push the total above the upper bound
 -- we set.
 -- @
-randomImprove :: forall m e. MonadRandom m => CoinSelectionAlgorithm m e
+randomImprove :: MonadRandom m => CoinSelectionAlgorithm m e
 randomImprove = CoinSelectionAlgorithm payForOutputs
 
 payForOutputs
@@ -137,7 +136,7 @@ payForOutputs opt outs utxo = do
 
 -- | Perform a random selection on a given output, without improvement.
 makeSelection
-    :: forall m. MonadRandom m
+    :: MonadRandom m
     => (Word64, UTxO, [([(TxIn, TxOut)], TxOut)])
     -> TxOut
     -> MaybeT m (Word64, UTxO, [([(TxIn, TxOut)], TxOut)])
@@ -150,7 +149,7 @@ makeSelection (maxNumInputs, utxo0, selection) txout = do
         )
   where
     coverRandomly
-        :: forall m. MonadRandom m
+        :: MonadRandom m
         => ([(TxIn, TxOut)], UTxO)
         -> MaybeT m ([(TxIn, TxOut)], UTxO)
     coverRandomly (inps, utxo)
@@ -163,7 +162,7 @@ makeSelection (maxNumInputs, utxo0, selection) txout = do
 
 -- | Perform an improvement to random selection on a given output.
 improveTxOut
-    :: forall m. MonadRandom m
+    :: MonadRandom m
     => (Word64, CoinSelection, UTxO)
     -> ([(TxIn, TxOut)], TxOut)
     -> m (Word64, CoinSelection, UTxO)
@@ -182,7 +181,7 @@ improveTxOut (maxN0, selection, utxo0) (inps0, txout) = do
     target = mkTargetRange txout
 
     improve
-        :: forall m. MonadRandom m
+        :: MonadRandom m
         => (Word64, [(TxIn, TxOut)], UTxO)
         -> m (Word64, [(TxIn, TxOut)], UTxO)
     improve (maxN, inps, utxo)

--- a/src/Cardano/CoinSelection/Random.hs
+++ b/src/Cardano/CoinSelection/Random.hs
@@ -10,7 +10,7 @@
 -- input selection algorithm
 
 module Cardano.CoinSelection.Random
-    ( random
+    ( randomImprove
     ) where
 
 import Prelude
@@ -110,8 +110,8 @@ data TargetRange = TargetRange
 -- that a randomly chosen UTxO entry will push the total above the upper bound
 -- we set.
 -- @
-random :: forall m e. MonadRandom m => CoinSelectionAlgorithm m e
-random = CoinSelectionAlgorithm payForOutputs
+randomImprove :: forall m e. MonadRandom m => CoinSelectionAlgorithm m e
+randomImprove = CoinSelectionAlgorithm payForOutputs
 
 payForOutputs
     :: MonadRandom m

--- a/src/Cardano/CoinSelection/Random.hs
+++ b/src/Cardano/CoinSelection/Random.hs
@@ -6,9 +6,9 @@
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
 --
--- This module contains the implementation of random
--- input selection algorithm
-
+-- This module contains an implementation of the __random-improve__ coin
+-- selection algorithm.
+--
 module Cardano.CoinSelection.Random
     ( randomImprove
     ) where

--- a/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -9,7 +9,11 @@ module Cardano.CoinSelection.LargestFirstSpec
 import Prelude
 
 import Cardano.CoinSelection
-    ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
+    ( CoinSelection (..)
+    , CoinSelectionAlgorithm (..)
+    , CoinSelectionOptions (..)
+    , ErrCoinSelection (..)
+    )
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.CoinSelectionSpec
@@ -242,7 +246,7 @@ propOutputOrderIrrelevant (CoinSelProp utxo txOuts) = monadicIO $ QC.run $ do
     options =
         CoinSelectionOptions (const 100) noValidation
     runSelectionFor outs =
-        runIdentity $ runExceptT $ largestFirst options outs utxo
+        runIdentity $ runExceptT $ selectCoins largestFirst options outs utxo
 
 propAtLeast
     :: CoinSelProp
@@ -252,7 +256,7 @@ propAtLeast (CoinSelProp utxo txOuts) =
   where
     prop (CoinSelection inps _ _) =
         L.length inps `shouldSatisfy` (>= NE.length txOuts)
-    selection = runIdentity $ runExceptT $
+    selection = runIdentity $ runExceptT $ selectCoins
         largestFirst (CoinSelectionOptions (const 100) noValidation) txOuts utxo
 
 propInputDecreasingOrder
@@ -270,5 +274,5 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
             `shouldSatisfy`
             (>= (getExtremumValue L.maximum utxo'))
     getExtremumValue f = f . map (getCoin . coin . snd)
-    selection = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions (const 100) noValidation) txOuts utxo
+    selection = runIdentity $ runExceptT $ selectCoins largestFirst
+        (CoinSelectionOptions (const 100) noValidation) txOuts utxo

--- a/test/Cardano/CoinSelection/RandomSpec.hs
+++ b/test/Cardano/CoinSelection/RandomSpec.hs
@@ -9,7 +9,11 @@ module Cardano.CoinSelection.RandomSpec
 import Prelude
 
 import Cardano.CoinSelection
-    ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
+    ( CoinSelection (..)
+    , CoinSelectionAlgorithm (..)
+    , CoinSelectionOptions (..)
+    , ErrCoinSelection (..)
+    )
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.CoinSelection.Random
@@ -252,9 +256,9 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
     prop (CoinSelection inps1 _ _, CoinSelection inps2 _ _) =
         L.length inps1 `shouldSatisfy` (>= L.length inps2)
     (selection1,_) = withDRG drg
-        (runExceptT $ random opt txOuts utxo)
+        (runExceptT $ selectCoins random opt txOuts utxo)
     selection2 = runIdentity $ runExceptT $
-        largestFirst opt txOuts utxo
+        selectCoins largestFirst opt txOuts utxo
     opt = CoinSelectionOptions (const 100) noValidation
 
 propErrors
@@ -269,7 +273,7 @@ propErrors drg (CoinSelProp utxo txOuts) = do
     prop (err1, err2) =
         err1 === err2
     (selection1,_) = withDRG drg
-        (runExceptT $ random opt txOuts utxo)
+        (runExceptT $ selectCoins random opt txOuts utxo)
     selection2 = runIdentity $ runExceptT $
-        largestFirst opt txOuts utxo
+        selectCoins largestFirst opt txOuts utxo
     opt = (CoinSelectionOptions (const 1) noValidation)

--- a/test/Cardano/CoinSelection/RandomSpec.hs
+++ b/test/Cardano/CoinSelection/RandomSpec.hs
@@ -17,7 +17,7 @@ import Cardano.CoinSelection
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.CoinSelection.Random
-    ( random )
+    ( randomImprove )
 import Cardano.CoinSelectionSpec
     ( CoinSelProp (..)
     , CoinSelectionFixture (..)
@@ -52,7 +52,7 @@ spec = do
     describe "Coin selection : random algorithm unit tests" $ do
         let oneAda = 1000000
 
-        coinSelectionUnitTest random ""
+        coinSelectionUnitTest randomImprove ""
             (Right $ CoinSelectionResult
                 { rsInputs = [1,1,1,1]
                 , rsChange = [2]
@@ -65,7 +65,7 @@ spec = do
                 , txOutputs = 2 :| []
                 })
 
-        coinSelectionUnitTest random ""
+        coinSelectionUnitTest randomImprove ""
             (Right $ CoinSelectionResult
                 { rsInputs = [1,1,1,1,1,1]
                 , rsChange = [2,1]
@@ -78,7 +78,7 @@ spec = do
                 , txOutputs = 2 :| [1]
                 })
 
-        coinSelectionUnitTest random ""
+        coinSelectionUnitTest randomImprove ""
             (Right $ CoinSelectionResult
                 { rsInputs = [1,1,1,1,1]
                 , rsChange = [2]
@@ -91,7 +91,7 @@ spec = do
                 , txOutputs = 2 :| [1]
                 })
 
-        coinSelectionUnitTest random ""
+        coinSelectionUnitTest randomImprove ""
             (Right $ CoinSelectionResult
                 { rsInputs = [1,1,1,1]
                 , rsChange = [1]
@@ -104,7 +104,7 @@ spec = do
                 , txOutputs = 2 :| [1]
                 })
 
-        coinSelectionUnitTest random ""
+        coinSelectionUnitTest randomImprove ""
             (Right $ CoinSelectionResult
                 { rsInputs = [5]
                 , rsChange = [3]
@@ -117,7 +117,7 @@ spec = do
                 , txOutputs = 2 :| []
                 })
 
-        coinSelectionUnitTest random ""
+        coinSelectionUnitTest randomImprove ""
             (Right $ CoinSelectionResult
                 { rsInputs = [10,10]
                 , rsChange = [8,8]
@@ -131,7 +131,7 @@ spec = do
                 , txOutputs = 2 :| [2]
                 })
 
-        coinSelectionUnitTest random "cannot cover aim, but only min"
+        coinSelectionUnitTest randomImprove "cannot cover aim, but only min"
             (Right $ CoinSelectionResult
                 { rsInputs = [1,1,1,1]
                 , rsChange = [1]
@@ -144,7 +144,7 @@ spec = do
                 , txOutputs = 3 :| []
                 })
 
-        coinSelectionUnitTest random "REG CO-450: no fallback"
+        coinSelectionUnitTest randomImprove "REG CO-450: no fallback"
             (Right $ CoinSelectionResult
                 { rsInputs = [oneAda, oneAda, oneAda, oneAda]
                 , rsChange = [oneAda, oneAda `div` 2]
@@ -157,7 +157,7 @@ spec = do
                 , txOutputs = 2*oneAda :| [oneAda `div` 2]
                 })
 
-        coinSelectionUnitTest random
+        coinSelectionUnitTest randomImprove
             "enough funds, proper fragmentation, inputs depleted"
             (Left ErrUxtoFullyDepleted)
             (CoinSelectionFixture
@@ -167,7 +167,7 @@ spec = do
                 , txOutputs = 38 :| [1]
                 })
 
-        coinSelectionUnitTest random ""
+        coinSelectionUnitTest randomImprove ""
             (Left $ ErrMaximumInputCountExceeded 2)
             (CoinSelectionFixture
                 { maxNumOfInputs = 2
@@ -176,7 +176,7 @@ spec = do
                 , txOutputs = 3 :| []
                 })
 
-        coinSelectionUnitTest random "each output needs <maxNumOfInputs"
+        coinSelectionUnitTest randomImprove "each output needs <maxNumOfInputs"
             (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
@@ -185,7 +185,7 @@ spec = do
                 , txOutputs = NE.fromList (replicate 100 1)
                 })
 
-        coinSelectionUnitTest random "each output needs >maxNumInputs"
+        coinSelectionUnitTest randomImprove "each output needs >maxNumInputs"
             (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
@@ -194,7 +194,7 @@ spec = do
                 , txOutputs = NE.fromList (replicate 10 10)
                 })
 
-        coinSelectionUnitTest random ""
+        coinSelectionUnitTest randomImprove ""
             (Left $ ErrUtxoBalanceInsufficient 39 40)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -203,7 +203,7 @@ spec = do
                 , txOutputs = 40 :| []
                 })
 
-        coinSelectionUnitTest random ""
+        coinSelectionUnitTest randomImprove ""
             (Left $ ErrUtxoBalanceInsufficient 39 43)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -212,7 +212,7 @@ spec = do
                 , txOutputs = 40 :| [1,1,1]
                 })
 
-        coinSelectionUnitTest random ""
+        coinSelectionUnitTest randomImprove ""
             (Left $ ErrUtxoNotFragmentedEnough 3 4)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -221,7 +221,7 @@ spec = do
                 , txOutputs = 40 :| [1,1,1]
                 })
 
-        coinSelectionUnitTest random "custom validation"
+        coinSelectionUnitTest randomImprove "custom validation"
             (Left $ ErrInvalidSelection ErrValidation)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -256,7 +256,7 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
     prop (CoinSelection inps1 _ _, CoinSelection inps2 _ _) =
         L.length inps1 `shouldSatisfy` (>= L.length inps2)
     (selection1,_) = withDRG drg
-        (runExceptT $ selectCoins random opt txOuts utxo)
+        (runExceptT $ selectCoins randomImprove opt txOuts utxo)
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst opt txOuts utxo
     opt = CoinSelectionOptions (const 100) noValidation
@@ -273,7 +273,7 @@ propErrors drg (CoinSelProp utxo txOuts) = do
     prop (err1, err2) =
         err1 === err2
     (selection1,_) = withDRG drg
-        (runExceptT $ selectCoins random opt txOuts utxo)
+        (runExceptT $ selectCoins randomImprove opt txOuts utxo)
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst opt txOuts utxo
     opt = (CoinSelectionOptions (const 1) noValidation)

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -13,7 +13,7 @@ module Cardano.FeeSpec
 import Prelude
 
 import Cardano.CoinSelection
-    ( CoinSelection (..) )
+    ( CoinSelection (..), CoinSelectionAlgorithm (..) )
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.Fee
@@ -567,7 +567,7 @@ genSelection :: NonEmpty TxOut -> Gen CoinSelection
 genSelection outs = do
     let opts = CS.CoinSelectionOptions (const 100) (const $ pure ())
     utxo <- vectorOf (NE.length outs * 3) arbitrary >>= genUTxO
-    case runIdentity $ runExceptT $ largestFirst opts outs utxo of
+    case runIdentity $ runExceptT $ selectCoins largestFirst opts outs utxo of
         Left _ -> genSelection outs
         Right (s,_) -> return s
 


### PR DESCRIPTION
## Related Issue

https://github.com/input-output-hk/cardano-wallet/issues/1381

## Summary

This PR introduces an abstract `CoinSelectionAlgorithm` type.

This type provides a _shared interface_ that all coin selection algorithms implement, as well as a place to document the common features of such algorithms.

## Limitations

The `CoinSelectionAlgorithm` abstraction does not deal with migration, as this is a rather special case.