### PR TITLE
Revise the `Random-Improve` module.

### DIFF
--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -2,7 +2,7 @@
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
 --
--- This module contains an implementation of the __largest first__ coin
+-- This module contains an implementation of the __Largest-First__ coin
 -- selection algorithm.
 --
 module Cardano.CoinSelection.LargestFirst (
@@ -36,7 +36,7 @@ import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 
--- | Generate a coin selection according to the __largest first__ algorithm.
+-- | An implementation of the __Largest-First__ coin selection algorithm.
 --
 -- === State Maintained by the Algorithm
 --

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -38,7 +38,16 @@ import qualified Data.Map.Strict as Map
 
 -- | An implementation of the __Largest-First__ coin selection algorithm.
 --
--- === State Maintained by the Algorithm
+-- = Overview
+--
+-- The __Largest-First__ algorithm processes outputs in /descending order of/
+-- /value/, from /largest/ to /smallest/.
+--
+-- For each output, it repeatedly selects the /largest/ remaining unspent UTxO
+-- entry until the value of selected entries is greater than or equal to the
+-- value of that output.
+--
+-- = State Maintained by the Algorithm
 --
 -- At all stages of processing, the algorithm maintains:
 --
@@ -48,7 +57,7 @@ import qualified Data.Map.Strict as Map
 --      sorted into /descending order of coin value/.
 --
 --      The /head/ of the list is always the remaining UTxO entry with the
---      /greatest coin value/.
+--      /largest coin value/.
 --
 --      Entries are incrementally removed from the /head/ of the list as the
 --      algorithm proceeds, until the list is empty.
@@ -59,7 +68,7 @@ import qualified Data.Map.Strict as Map
 --      into /descending order of coin value/.
 --
 --      The /head/ of the list is always the unpaid output with the
---      /greatest coin value/.
+--      /largest coin value/.
 --
 --      Entries are incrementally removed from the /head/ of the list as the
 --      algorithm proceeds, until the list is empty.
@@ -71,7 +80,7 @@ import qualified Data.Map.Strict as Map
 --      Entries are incrementally added as each output is paid for, until the
 --      /unpaid output list/ is empty.
 --
--- === Cardinality Rules
+-- = Cardinality Rules
 --
 -- The algorithm requires that:
 --
@@ -83,7 +92,7 @@ import qualified Data.Map.Strict as Map
 --
 --      (A single UTxO entry __cannot__ be used to pay for multiple outputs.)
 --
--- === Order of Processing
+-- = Order of Processing
 --
 -- The algorithm proceeds according to the following sequence of steps:
 --
@@ -122,7 +131,7 @@ import qualified Data.Map.Strict as Map
 --
 --      Otherwise, return to /Step 1/.
 --
--- === Successful Termination
+-- = Termination
 --
 -- The algorithm terminates __successfully__ if the /remaining UTxO list/ is
 -- not depleted before the /unpaid output list/ can be fully depleted (i.e., if
@@ -131,7 +140,7 @@ import qualified Data.Map.Strict as Map
 -- The /accumulated coin selection/ and /remaining UTxO list/ are returned to
 -- the caller.
 --
--- === Unsuccessful Termination
+-- === Failure Modes
 --
 -- The algorithm terminates with an __error__ if:
 --

--- a/src/Cardano/CoinSelection/Random.hs
+++ b/src/Cardano/CoinSelection/Random.hs
@@ -85,7 +85,7 @@ import qualified Data.List.NonEmpty as NE
 -- UTxO entries.
 --
 -- However, if the remaining UTxO set is completely exhausted before all
--- outputs can be processed, the algorithm terminates and delegates to the
+-- outputs can be processed, the algorithm terminates and falls back to the
 -- __Largest-First__ algorithm. (See 'largestFirst'.)
 --
 -- === Phase 2: Improvement
@@ -232,7 +232,7 @@ payForOutputs options outputsRequested utxo = do
             validateSelection finalSelection $>
                 (finalSelection, utxoRemaining')
         Nothing ->
-            -- In the case that we fail to generate a selection, delegate to
+            -- In the case that we fail to generate a selection, fall back to
             -- the "Largest-First" algorithm as a backup.
             selectCoins largestFirst options outputsRequested utxo
   where

--- a/src/Cardano/CoinSelection/Random.hs
+++ b/src/Cardano/CoinSelection/Random.hs
@@ -56,16 +56,6 @@ import Data.Word
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 
--- | Target range for picking inputs
-data TargetRange = TargetRange
-    { targetMin :: Word64
-        -- ^ Minimum value to cover: only the requested amount, no change at all
-    , targetAim :: Word64
-        -- ^ Ideal case: change equal to requested amount
-    , targetMax :: Word64
-        -- ^ Maximum value: an arbitrary upper bound (e.g. @2 * targetMin@)
-    }
-
 -- | Random-Improve Algorithm
 --
 -- 1. Randomly select outputs from the UTxO until the payment value is covered.
@@ -218,10 +208,15 @@ improveTxOut (maxN0, selection, utxo0) (inps0, txout) = do
                                  Internals
 -------------------------------------------------------------------------------}
 
--- | Re-wrap 'pickRandom' in a 'MaybeT' monad
-pickRandomT :: MonadRandom m => UTxO -> MaybeT m ((TxIn, TxOut), UTxO)
-pickRandomT =
-    MaybeT . fmap (\(m,u) -> (,u) <$> m) . pickRandom
+-- | Target range for picking inputs
+data TargetRange = TargetRange
+    { targetMin :: Word64
+        -- ^ Minimum value to cover: only the requested amount, no change at all
+    , targetAim :: Word64
+        -- ^ Ideal case: change equal to requested amount
+    , targetMax :: Word64
+        -- ^ Maximum value: an arbitrary upper bound (e.g. @2 * targetMin@)
+    }
 
 -- | Compute the target range for a given output
 mkTargetRange :: TxOut -> TargetRange
@@ -230,6 +225,11 @@ mkTargetRange (TxOut _ (Coin c)) = TargetRange
     , targetAim = 2 * c
     , targetMax = 3 * c
     }
+
+-- | Re-wrap 'pickRandom' in a 'MaybeT' monad
+pickRandomT :: MonadRandom m => UTxO -> MaybeT m ((TxIn, TxOut), UTxO)
+pickRandomT =
+    MaybeT . fmap (\(m,u) -> (,u) <$> m) . pickRandom
 
 -- | Compute corresponding change outputs from a target output and a selection
 -- of inputs.

--- a/src/Cardano/CoinSelection/Random.hs
+++ b/src/Cardano/CoinSelection/Random.hs
@@ -5,7 +5,7 @@
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
 --
--- This module contains an implementation of the __random-improve__ coin
+-- This module contains an implementation of the __Random-Improve__ coin
 -- selection algorithm.
 --
 module Cardano.CoinSelection.Random
@@ -56,7 +56,7 @@ import Data.Word
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 
--- | Random-Improve Algorithm
+-- | An implementation of the __Random-Improve__ coin selection algorithm.
 --
 -- 1. Randomly select outputs from the UTxO until the payment value is covered.
 --    (In the rare case that this fails because the maximum number of

--- a/src/Cardano/CoinSelection/Random.hs
+++ b/src/Cardano/CoinSelection/Random.hs
@@ -133,7 +133,13 @@ payForOutputs options outputsRequested utxo = do
     validateSelection =
         except . left ErrInvalidSelection . validate options
 
--- | Perform a random selection on a given output, without improvement.
+-- | Randomly select entries from the given UTxO set, until the total value of
+--   selected entries is greater than or equal to the given output value.
+--
+-- Once a random selection has been made that meets the above criterion, this
+-- function returns that selection as is, making no attempt to improve upon
+-- the selection in any way.
+--
 makeRandomSelection
     :: MonadRandom m
     => (Word64, UTxO, [([CoinSelectionInput], TxOut)])

--- a/src/Cardano/CoinSelection/Random.hs
+++ b/src/Cardano/CoinSelection/Random.hs
@@ -208,17 +208,28 @@ improveSelection (maxN0, selection, utxo0) (inps0, txout) = do
                                  Internals
 -------------------------------------------------------------------------------}
 
--- | Target range for picking inputs
+-- | Represents a target range of /total input values/ for a given output.
+--
+-- In this context, /total input value/ refers to the total value of a set of
+-- inputs selected to pay for a given output.
+--
 data TargetRange = TargetRange
     { targetMin :: Word64
-        -- ^ Minimum value to cover: only the requested amount, no change at all
+        -- ^ The minimum value, corresponding to exactly the requested target
+        -- amount, and a change amount of zero.
     , targetAim :: Word64
-        -- ^ Ideal case: change equal to requested amount
+        -- ^ The ideal value, corresponding to exactly twice the requested
+        -- target amount, and a change amount equal to the requested amount.
     , targetMax :: Word64
-        -- ^ Maximum value: an arbitrary upper bound (e.g. @2 * targetMin@)
+        -- ^ The maximum value, corresponding to exactly three times the
+        -- requested amount, and a change amount equal to twice the requested
+        -- amount.
     }
 
--- | Compute the target range for a given output
+-- | Compute the target range of /total input values/ for a given output.
+--
+-- See 'TargetRange'.
+--
 mkTargetRange :: TxOut -> TargetRange
 mkTargetRange (TxOut _ (Coin c)) = TargetRange
     { targetMin = c


### PR DESCRIPTION
## Related Issue

https://github.com/input-output-hk/cardano-wallet/issues/1382

## Summary

The primary purpose of this PR is to revise documentation for the `Random-Improve` module.

However, this PR also makes a small number of _related_ changes:

- [x] Adjusts documentation for `Largest-First` so that both coin selection algorithms have a similar documentation structure.
- [x] Introduces the type synonym `CoinSelectionInput = (TxIn, TxOut)` to aid readability, and to make it explicit that values of this type are intended to be inputs to a `CoinSelection`.
- [x] Adjusts the naming of some identifiers for consistency across modules and to be consistent with terminology used in the documentation. (So that people reading the code are presented with a consistent vocabulary.)
- [x] Revises the definitions of some functions so that constants are defined within `where` clauses instead of within monadic `let` bindings.
- [x] Groups related utility types and functions together at the end of the module.