### PR TITLE
Use the Random-Improve algorithm's full name in the module name.

### DIFF
--- a/cardano-coin-selection.cabal
+++ b/cardano-coin-selection.cabal
@@ -53,7 +53,7 @@ library
       Cardano.CoinSelection
       Cardano.CoinSelection.LargestFirst
       Cardano.CoinSelection.Migration
-      Cardano.CoinSelection.Random
+      Cardano.CoinSelection.RandomImprove
       Cardano.Fee
       Cardano.Types
       Data.Quantity
@@ -95,7 +95,7 @@ test-suite unit
   other-modules:
       Cardano.CoinSelection.LargestFirstSpec
       Cardano.CoinSelection.MigrationSpec
-      Cardano.CoinSelection.RandomSpec
+      Cardano.CoinSelection.RandomImproveSpec
       Cardano.CoinSelectionSpec
       Cardano.FeeSpec
       Cardano.TypesSpec

--- a/src/Cardano/CoinSelection/RandomImprove.hs
+++ b/src/Cardano/CoinSelection/RandomImprove.hs
@@ -8,7 +8,7 @@
 -- This module contains an implementation of the __Random-Improve__ coin
 -- selection algorithm.
 --
-module Cardano.CoinSelection.Random
+module Cardano.CoinSelection.RandomImprove
     ( randomImprove
     ) where
 

--- a/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Cardano.CoinSelection.RandomSpec
+module Cardano.CoinSelection.RandomImproveSpec
     ( spec
     ) where
 
@@ -16,7 +16,7 @@ import Cardano.CoinSelection
     )
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
-import Cardano.CoinSelection.Random
+import Cardano.CoinSelection.RandomImprove
     ( randomImprove )
 import Cardano.CoinSelectionSpec
     ( CoinSelProp (..)


### PR DESCRIPTION
## Related Issue

https://github.com/input-output-hk/cardano-wallet/issues/1380

## Summary

This PR renames the module that implements Random-Improve from `Random` to `RandomImprove`.

This is for consistency with other algorithms, such as Largest-First, where the module name (`LargestFirst`) and top-level bindings (`largestFirst`) are consistent with the name of the algorithm.