### PR TITLE
Quieter `show` for newtypes.

### DIFF
--- a/cardano-coin-selection.cabal
+++ b/cardano-coin-selection.cabal
@@ -45,6 +45,7 @@ library
     , deepseq
     , fmt
     , memory
+    , quiet
     , text
     , transformers
   hs-source-dirs:

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
@@ -64,6 +65,8 @@ import GHC.Generics
     ( Generic )
 import GHC.Stack
     ( HasCallStack )
+import Quiet
+    ( Quiet (Quiet) )
 
 import qualified Data.List as L
 
@@ -72,8 +75,10 @@ import qualified Data.List as L
 -------------------------------------------------------------------------------}
 
 -- | A 'Fee', isomorph to 'Coin' but ease type-signatures and readability.
-newtype Fee = Fee { getFee :: Word64 }
-    deriving (Eq, Ord, Show)
+newtype Fee = Fee
+    { getFee :: Word64 }
+    deriving stock (Eq, Generic, Ord)
+    deriving Show via (Quiet Fee)
 
 {-------------------------------------------------------------------------------
                                 Fee Calculation

--- a/src/Cardano/Types.hs
+++ b/src/Cardano/Types.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -78,6 +78,8 @@ import GHC.TypeLits
     ( Symbol )
 import Numeric.Natural
     ( Natural )
+import Quiet
+    ( Quiet (Quiet) )
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -142,8 +144,9 @@ instance NFData FeePolicy
 -------------------------------------------------------------------------------}
 
 newtype Address = Address
-    { unAddress :: ByteString
-    } deriving (Show, Generic, Eq, Ord)
+    { unAddress :: ByteString }
+    deriving stock (Eq, Generic, Ord)
+    deriving Show via (Quiet Address)
 
 instance NFData Address
 

--- a/src/Cardano/Types.hs
+++ b/src/Cardano/Types.hs
@@ -265,8 +265,9 @@ class Dom a where
     dom :: a -> Set (DomElem a)
 
 newtype Hash (tag :: Symbol) = Hash { getHash :: ByteString }
-    deriving stock (Show, Generic, Eq, Ord)
+    deriving stock (Eq, Generic, Ord)
     deriving newtype (ByteArrayAccess)
+    deriving Show via (Quiet (Hash tag))
 
 instance NFData (Hash tag)
 

--- a/src/Cardano/Types.hs
+++ b/src/Cardano/Types.hs
@@ -167,8 +167,9 @@ instance Buildable Address where
 
 -- | Coins are stored as Lovelace (reminder: 1 Lovelace = 1e-6 ADA)
 newtype Coin = Coin
-    { getCoin :: Word64
-    } deriving stock (Show, Ord, Eq, Generic)
+    { getCoin :: Word64 }
+    deriving stock (Eq, Generic, Ord)
+    deriving Show via (Quiet Coin)
 
 instance NFData Coin
 

--- a/src/Cardano/Types.hs
+++ b/src/Cardano/Types.hs
@@ -187,9 +187,11 @@ isValidCoin c = c >= minBound && c <= maxBound
                                     UTxO
 -------------------------------------------------------------------------------}
 
-newtype UTxO = UTxO { getUTxO :: Map TxIn TxOut }
-    deriving stock (Show, Generic, Eq, Ord)
+newtype UTxO = UTxO
+    { getUTxO :: Map TxIn TxOut }
+    deriving stock (Eq, Generic, Ord)
     deriving newtype (Semigroup, Monoid)
+    deriving Show via (Quiet UTxO)
 
 instance NFData UTxO
 

--- a/src/Data/Quantity.hs
+++ b/src/Data/Quantity.hs
@@ -51,9 +51,6 @@ import Quiet
 --
 -- so mixing them up is more difficult.
 --
--- The unit is mostly a phantom type, but it is also included in the
--- @ToJSON@/@FromJSON@ instances.
---
 -- >>> Aeson.encode $ Quantity @"lovelace" 14
 -- {"unit":"lovelace","quantity":14}
 newtype Quantity (unit :: Symbol) a = Quantity { getQuantity :: a }

--- a/src/Data/Quantity.hs
+++ b/src/Data/Quantity.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -30,6 +30,8 @@ import GHC.Generics
     ( Generic )
 import GHC.TypeLits
     ( KnownSymbol, Symbol, symbolVal )
+import Quiet
+    ( Quiet (Quiet) )
 
 -- | @Quantity (unit :: Symbol) a@ is a primitive @a@  multiplied by an @unit@.
 --
@@ -55,8 +57,9 @@ import GHC.TypeLits
 -- >>> Aeson.encode $ Quantity @"lovelace" 14
 -- {"unit":"lovelace","quantity":14}
 newtype Quantity (unit :: Symbol) a = Quantity { getQuantity :: a }
-    deriving stock (Generic, Show, Eq, Ord)
+    deriving stock (Eq, Generic, Ord)
     deriving newtype (Bounded, Enum)
+    deriving Show via (Quiet (Quantity unit a))
 
 instance Functor (Quantity any) where
     fmap f (Quantity a) = Quantity (f a)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
 resolver: lts-13.24
 packages:
 - .
-extra-deps: []
+extra-deps:
+- quiet-0.2


### PR DESCRIPTION
## Related Issue

Tangentially related to https://github.com/input-output-hk/cardano-coin-selection/issues/21.

## Summary

This small PR makes it easier to work with `cardano-coin-selection` interactively.

It reduces the verbosity of `show` for several `newtype`s, so that accessor function names are not included in the output.

**Before** applying this PR:
```hs
> divvyFee (Fee 15) $ fmap Coin [1, 2, 4, 8]
[(Fee {getFee = 1},Coin {getCoin = 1}),(Fee {getFee = 2},Coin {getCoin = 2}),(Fee {getFee = 4},Coin {getCoin = 4}),(Fee {getFee = 8},Coin {getCoin = 8})]
```

**After** applying this PR:
```hs
> divvyFee (Fee 15) $ fmap Coin [1, 2, 4, 8]
[(Fee 1,Coin 1),(Fee 2,Coin 2),(Fee 4,Coin 4),(Fee 8,Coin 8)]
```

