### PR TITLE
Extend tests and documentation for fee distribution function.

### DIFF
--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -273,7 +273,7 @@ reduceSingleChange (Fee fee, Coin chng)
 --
 -- == Pre-condition
 --
--- Every coin in the given list must be __non-zero__.
+-- Every coin in the given list must be __non-zero__ in value.
 --
 -- == Examples
 --
@@ -290,11 +290,15 @@ reduceSingleChange (Fee fee, Coin chng)
 -- [(Fee 2, Coin 1), (Fee 4, Coin 2), (Fee 8, Coin 4)]
 --
 distributeFee :: Fee -> NonEmpty Coin -> NonEmpty (Fee, Coin)
-distributeFee _ coins | Coin 0 `F.elem` coins =
-    error "distributeFee: one or more coins has a value of zero."
-distributeFee (Fee feeTotal) coins =
+distributeFee (Fee feeTotal) coinsUnsafe =
     NE.zip feesRounded coins
   where
+    -- A list of coins that are non-zero in value.
+    coins :: NonEmpty Coin
+    coins =
+        invariant "distributeFee: all coins must be non-zero in value."
+        coinsUnsafe (Coin 0 `F.notElem`)
+
     -- A list of rounded fee portions, where each fee portion deviates from the
     -- ideal unrounded portion by as small an amount as possible.
     feesRounded :: NonEmpty Fee

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -290,7 +290,7 @@ reduceSingleChange (Fee fee, Coin chng)
 -- [(Fee 2, Coin 1), (Fee 4, Coin 2), (Fee 8, Coin 4)]
 --
 distributeFee :: Fee -> NonEmpty Coin -> NonEmpty (Fee, Coin)
-distributeFee _ outs | Coin 0 `F.elem` outs =
+distributeFee _ coins | Coin 0 `F.elem` coins =
     error "distributeFee: one or more coins has a value of zero."
 distributeFee (Fee feeTotal) coins =
     NE.zip feesRounded coins

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -254,12 +254,28 @@ reduceSingleChange (Fee fee, Coin chng)
     | otherwise =
           Coin 0
 
--- | Proportionally divide the fee over each output.
+-- | Distribute the given fee over the given list of coins, so that each coin
+--   is allocated a fraction of the fee in proportion to its relative size.
 --
--- Pre-condition 1: The given outputs list shouldn't be empty
--- Pre-condition 2: None of the outputs should be null
+-- == Examples
 --
--- It returns the a list of pairs (fee, output).
+-- >>> divvyFee (Fee 2) [(Coin 1), (Coin 1)]
+-- [(Fee 1, Coin 1), (Fee 1, Coin 1)]
+--
+-- >>> divvyFee (Fee 4) [(Coin 1), (Coin 1)]
+-- [(Fee 2, Coin 1), (Fee 2, Coin 1)]
+--
+-- >>> divvyFee (Fee 7) [(Coin 1), (Coin 2), (Coin 4)]
+-- [(Fee 1, Coin 1), (Fee 2, Coin 2), (Fee 4, Coin 4)]
+--
+-- >>> divvyFee (Fee 14) [(Coin 1), (Coin 2), (Coin 4)]
+-- [(Fee 2, Coin 1), (Fee 4, Coin 2), (Fee 8, Coin 4)]
+--
+-- == Pre-conditions
+--
+-- 1. The given list of coins must not be empty.
+-- 2. The given list of coins must all be positive.
+--
 divvyFee :: Fee -> [Coin] -> [(Fee, Coin)]
 divvyFee _ outs | (Coin 0) `elem` outs =
     error "divvyFee: some outputs are null"

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -270,6 +270,10 @@ reduceSingleChange (Fee fee, Coin chng)
 -- | Distribute the given fee over the given list of coins, so that each coin
 --   is allocated a __fraction__ of the fee in proportion to its relative size.
 --
+-- == Pre-condition
+--
+-- Every coin in the given list must be __non-zero__.
+--
 -- == Examples
 --
 -- >>> distributeFee (Fee 2) [(Coin 1), (Coin 1)]
@@ -283,10 +287,6 @@ reduceSingleChange (Fee fee, Coin chng)
 --
 -- >>> distributeFee (Fee 14) [(Coin 1), (Coin 2), (Coin 4)]
 -- [(Fee 2, Coin 1), (Fee 4, Coin 2), (Fee 8, Coin 4)]
---
--- == Pre-condition
---
--- Every coin in the given list must be __non-zero__.
 --
 distributeFee :: Fee -> NonEmpty Coin -> NonEmpty (Fee, Coin)
 distributeFee _ outs | Coin 0 `F.elem` outs =

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -389,3 +389,8 @@ splitChange = go
 --
 fractionalPart :: Rational -> Rational
 fractionalPart = snd . properFraction @_ @Integer
+
+-- | Apply the same function multiple times to a value.
+--
+applyN :: Int -> (a -> a) -> a -> a
+applyN n f = F.foldr (.) id (replicate n f)

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -372,3 +372,20 @@ splitChange = go
             if isValidCoin newChange
             then newChange : go newRemaining as
             else a : go rest as
+
+--------------------------------------------------------------------------------
+-- Utilities
+--------------------------------------------------------------------------------
+
+-- | Extract the fractional part of a rational number.
+--
+-- Examples:
+--
+-- >>> fractionalPart (3 % 2)
+-- 1 % 2
+--
+-- >>> fractionalPart (11 % 10)
+-- 1 % 10
+--
+fractionalPart :: Rational -> Rational
+fractionalPart = snd . properFraction @_ @Integer

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -268,7 +268,7 @@ reduceSingleChange (Fee fee, Coin chng)
           Coin 0
 
 -- | Distribute the given fee over the given list of coins, so that each coin
---   is allocated a fraction of the fee in proportion to its relative size.
+--   is allocated a __fraction__ of the fee in proportion to its relative size.
 --
 -- == Examples
 --

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -24,7 +24,7 @@ module Cardano.Fee
 
       -- * Fee Calculation
     , computeFee
-    , divvyFee
+    , distributeFee
 
       -- * Fee Adjustment
     , FeeOptions (..)
@@ -255,7 +255,7 @@ rebalanceChangeOutputs opt totalFee chgs =
             removeDust (dustThreshold opt)
             $ map reduceSingleChange
             $ F.toList
-            $ divvyFee totalFee
+            $ distributeFee totalFee
             $ x :| xs
 
 -- | Reduce single change output by a given fee amount. If fees are too big for
@@ -272,26 +272,26 @@ reduceSingleChange (Fee fee, Coin chng)
 --
 -- == Examples
 --
--- >>> divvyFee (Fee 2) [(Coin 1), (Coin 1)]
+-- >>> distributeFee (Fee 2) [(Coin 1), (Coin 1)]
 -- [(Fee 1, Coin 1), (Fee 1, Coin 1)]
 --
--- >>> divvyFee (Fee 4) [(Coin 1), (Coin 1)]
+-- >>> distributeFee (Fee 4) [(Coin 1), (Coin 1)]
 -- [(Fee 2, Coin 1), (Fee 2, Coin 1)]
 --
--- >>> divvyFee (Fee 7) [(Coin 1), (Coin 2), (Coin 4)]
+-- >>> distributeFee (Fee 7) [(Coin 1), (Coin 2), (Coin 4)]
 -- [(Fee 1, Coin 1), (Fee 2, Coin 2), (Fee 4, Coin 4)]
 --
--- >>> divvyFee (Fee 14) [(Coin 1), (Coin 2), (Coin 4)]
+-- >>> distributeFee (Fee 14) [(Coin 1), (Coin 2), (Coin 4)]
 -- [(Fee 2, Coin 1), (Fee 4, Coin 2), (Fee 8, Coin 4)]
 --
 -- == Pre-condition
 --
 -- Every coin in the given list must be __non-zero__.
 --
-divvyFee :: Fee -> NonEmpty Coin -> NonEmpty (Fee, Coin)
-divvyFee _ outs | Coin 0 `F.elem` outs =
-    error "divvyFee: one or more coins has a value of zero."
-divvyFee (Fee feeTotal) coins =
+distributeFee :: Fee -> NonEmpty Coin -> NonEmpty (Fee, Coin)
+distributeFee _ outs | Coin 0 `F.elem` outs =
+    error "distributeFee: one or more coins has a value of zero."
+distributeFee (Fee feeTotal) coins =
     NE.zip feesRounded coins
   where
     -- A list of rounded fee portions, where each fee portion deviates from the

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -134,7 +134,7 @@ spec = do
             }) (Right $ FeeOutput
             { csInps = [20,20]
             , csOuts = [17,18]
-            , csChngs = [1,2]
+            , csChngs = [2,1]
             })
 
         -- Fee divvied, dust removed (dust = 0)


### PR DESCRIPTION
## Related Issue

In preparation for further work on #21.

## Summary

This PR:

- [x] enhances the Haddock documentation for the fee distribution function, and adds a few worked examples;
- [x] adds a **property test** to verify that the fee distribution is **fair**.
- [x] changes the function type so that only **non-empty lists** are accepted;
- [x] removes the test for the non-empty list precondition (as it is now redundant);
- [x] documents the internals of the function in a way that can be easily translated to the specification document.