### PR TITLE
Add property to verify that fee distributions are optimal.

### DIFF
--- a/cardano-coin-selection.cabal
+++ b/cardano-coin-selection.cabal
@@ -58,6 +58,7 @@ library
       Cardano.Fee
       Cardano.Types
       Data.Quantity
+      Numeric.Rounding
 
 test-suite unit
   default-language:

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -74,6 +74,8 @@ import GHC.Generics
     ( Generic )
 import GHC.Stack
     ( HasCallStack )
+import Numeric.Rounding
+    ( RoundingDirection (..), round )
 import Quiet
     ( Quiet (Quiet) )
 
@@ -471,23 +473,3 @@ fractionalPart = snd . properFraction @_ @Integer
 --
 applyN :: Int -> (a -> a) -> a -> a
 applyN n f = F.foldr (.) id (replicate n f)
-
--- | Indicates a rounding direction to be used when converting from a
---   fractional value to an integral value.
---
--- See 'round'.
---
-data RoundingDirection
-    = RoundUp
-      -- ^ Round up to the nearest integral value.
-    | RoundDown
-      -- ^ Round down to the nearest integral value.
-    deriving (Eq, Show)
-
--- | Use the given rounding direction to round the given fractional value,
---   producing an integral result.
---
-round :: (RealFrac a, Integral b) => RoundingDirection -> a -> b
-round = \case
-    RoundUp -> ceiling
-    RoundDown -> floor

--- a/src/Numeric/Rounding.hs
+++ b/src/Numeric/Rounding.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- Provides functionality relating to rounding.of fractional numbers.
+
+module Numeric.Rounding
+    ( RoundingDirection (..)
+    , round
+    ) where
+
+import Prelude hiding
+    ( round )
+
+-- | Indicates a rounding direction to be used when converting from a
+--   fractional value to an integral value.
+--
+-- See 'round'.
+--
+data RoundingDirection
+    = RoundUp
+      -- ^ Round up to the nearest integral value.
+    | RoundDown
+      -- ^ Round down to the nearest integral value.
+    deriving (Eq, Show)
+
+-- | Use the given rounding direction to round the given fractional value,
+--   producing an integral result.
+--
+round :: (RealFrac a, Integral b) => RoundingDirection -> a -> b
+round = \case
+    RoundUp -> ceiling
+    RoundDown -> floor

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -346,7 +346,7 @@ spec = do
 
     describe "distributeFee" $ do
         it "fee portions are all within unity of ideal unrounded portions"
-            (checkCoverage propDistributeFeeIsFair)
+            (checkCoverage propDistributeFeeFair)
         it "Σ fst (distributeFee fee outs) == fee"
             (checkCoverage propDistributeFeeSame)
         it "snd (distributeFee fee outs) == outs"
@@ -442,10 +442,10 @@ propDistributeFee prop (fee, outs) =
 -- | Verify that fees are distributed fairly across outputs, so that every
 --   rounded fee portion is always within unity of the ideal unrounded fee
 --   portion.
-propDistributeFeeIsFair
+propDistributeFeeFair
     :: (Fee, NonEmpty Coin)
     -> Property
-propDistributeFeeIsFair (fee, coins) = (.&&.)
+propDistributeFeeFair (fee, coins) = (.&&.)
     (F.all (uncurry (<=)) (NE.zip fees feeUpperBounds))
     (F.all (uncurry (>=)) (NE.zip fees feeLowerBounds))
   where

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -36,6 +36,8 @@ import Cardano.Types
     )
 import Control.Arrow
     ( left )
+import Control.Monad
+    ( replicateM )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
@@ -731,7 +733,9 @@ instance Arbitrary FeeOptions where
             }
 
 instance Arbitrary a => Arbitrary (NonEmpty a) where
-    arbitrary = (:|) <$> arbitrary <*> (take 10 <$> arbitrary)
+    arbitrary = do
+        tailLength <- choose (0, 10)
+        (:|) <$> arbitrary <*> replicateM tailLength arbitrary
     shrink = genericShrink
 
 instance Show FeeOptions where

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -4,13 +4,15 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.FeeSpec
     ( spec
     ) where
 
-import Prelude
+import Prelude hiding
+    ( round )
 
 import Cardano.CoinSelection
     ( CoinSelection (..), CoinSelectionAlgorithm (..) )
@@ -54,6 +56,8 @@ import Data.Word
     ( Word64 )
 import Fmt
     ( Buildable (..), nameF, tupleF )
+import Numeric.Rounding
+    ( RoundingDirection (..), round )
 import Test.Hspec
     ( Spec, SpecWith, before, describe, it, shouldBe, shouldSatisfy )
 import Test.QuickCheck
@@ -347,6 +351,8 @@ spec = do
     describe "distributeFee" $ do
         it "fee portions are all within unity of ideal unrounded portions"
             (checkCoverage propDistributeFeeFair)
+        it "fee portions are allocated optimally"
+            (checkCoverage propDistributeFeeOptimal)
         it "Σ fst (distributeFee fee outs) == fee"
             (checkCoverage propDistributeFeeSame)
         it "snd (distributeFee fee outs) == outs"
@@ -459,6 +465,54 @@ propDistributeFeeFair (fee, coins) = (.&&.)
         = fromIntegral c
         * fromIntegral (getFee fee)
         % fromIntegral (sum $ getCoin <$> coins)
+
+-- | Verify that fees are distributed optimally across coins, such that the
+-- absolute deviation from the ideal (unrounded) fee distribution is minimal.
+propDistributeFeeOptimal
+    :: Fee
+    -> NonEmpty Coin
+    -> Property
+propDistributeFeeOptimal fee coins = property $
+    computeDeviation (fst <$> distributeFee fee coins)
+        `shouldBe` minimumPossibleDeviation
+  where
+    -- Compute the deviation of a fee portion distribution from the ideal
+    -- unrounded fee portion distribution.
+    computeDeviation :: NonEmpty Fee -> Rational
+    computeDeviation feesRounded = F.sum $
+        NE.zipWith (\(Fee f) u -> abs (fromIntegral f - u))
+            feesRounded
+            idealUnroundedDistribution
+
+    -- The minimum deviation across all possible distributions for the given
+    -- fee and set of coins.
+    minimumPossibleDeviation :: Rational
+    minimumPossibleDeviation =
+        F.minimum $ computeDeviation <$> allPossibleDistributions
+
+    -- The set of all possible fee distributions for the given fee and coins.
+    allPossibleDistributions :: [NonEmpty Fee]
+    allPossibleDistributions = filter isValidDistribution $ NE.zipWith
+        (\f roundDir -> Fee $ fromIntegral @Integer $ round roundDir f)
+        idealUnroundedDistribution <$> allPossibleRoundings
+      where
+        -- Indicates whether the given distribution has the correct total fee.
+        isValidDistribution :: NonEmpty Fee -> Bool
+        isValidDistribution r = sum (getFee <$> r) == getFee fee
+
+        -- All possible ways to round an unrounded fee distribution.
+        allPossibleRoundings :: [NonEmpty RoundingDirection]
+        allPossibleRoundings = traverse (const [RoundUp, RoundDown]) coins
+
+    -- The ideal unrounded fee distribution.
+    idealUnroundedDistribution :: NonEmpty Rational
+    idealUnroundedDistribution = computeIdealFee <$> coins
+      where
+        computeIdealFee :: Coin -> Rational
+        computeIdealFee (Coin c)
+            = fromIntegral c
+            * fromIntegral (getFee fee)
+            % fromIntegral (sum $ getCoin <$> coins)
 
 -- | Sum of the fees divvied over each output is the same as the initial total
 -- fee.

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -677,7 +677,7 @@ instance Arbitrary FeeOptions where
             }
 
 instance Arbitrary a => Arbitrary (NonEmpty a) where
-    arbitrary = (:|) <$> arbitrary <*> arbitrary
+    arbitrary = (:|) <$> arbitrary <*> (take 10 <$> arbitrary)
     shrink = genericShrink
 
 instance Show FeeOptions where


### PR DESCRIPTION
## Related Issue

Preparation for #21.

## Summary

This PR adds a simple property to verify that the fee distribution produced by `distributeFee` is optimal.

Since `distributeFee` is restricted to generating **integer** fee distributions, for any given distribution there will be some deviation from the ideal **unrounded** fee distribution, caused by the particular choice of rounding.
    
This property verifies that the absolute deviation from the ideal unrounded fee distribution is minimal across all possible ways to round.

