### PR TITLE
Add property tests for dust coalescing.

### DIFF
--- a/src/Cardano/CoinSelection/Migration.hs
+++ b/src/Cardano/CoinSelection/Migration.hs
@@ -45,7 +45,7 @@ import Cardano.CoinSelection
     , inputBalance
     )
 import Cardano.Fee
-    ( Fee (..), FeeOptions (..) )
+    ( DustThreshold (..), Fee (..), FeeOptions (..) )
 import Cardano.Types
     ( Coin (..), TxIn (..), TxOut (..), UTxO (..) )
 import Control.Monad.Trans.State
@@ -100,12 +100,13 @@ depleteUTxO feeOpts batchSize utxo =
         , outputs = []
         , change =
             let chgs = mapMaybe (noDust . snd) inps
-            in if null chgs then [dustThreshold feeOpts] else chgs
+            in if null chgs then [threshold] else chgs
         }
       where
+        threshold = Coin $ getDustThreshold $ dustThreshold feeOpts
         noDust :: TxOut -> Maybe Coin
         noDust (TxOut _ c)
-            | c < dustThreshold feeOpts = Nothing
+            | c < threshold = Nothing
             | otherwise = Just c
 
     -- | Attempt to balance the coin selection by reducing or increasing the
@@ -153,7 +154,7 @@ depleteUTxO feeOpts batchSize utxo =
         c' = op (integer c)
 
         threshold :: Integer
-        threshold = integer (getCoin (dustThreshold feeOpts))
+        threshold = integer (getDustThreshold (dustThreshold feeOpts))
 
     getNextBatch :: State [a] [a]
     getNextBatch = do

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -131,9 +131,11 @@ data FeeOptions = FeeOptions
       --     b: 43.946 # additional minimal fees per byte of transaction size
     , dustThreshold
       :: Coin
-      -- ^ Change addresses below the given threshold will be evicted
-      -- from the created transaction. Setting 'dustThreshold' to 0
-      -- removes output equal to 0
+      -- ^ Defines the maximum size of a dust coin.
+      --
+      -- Change values that are less than or equal to this threshold will be
+      -- evicted from created transactions.
+      --
     } deriving (Generic)
 
 newtype ErrAdjustForFee

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -219,7 +219,8 @@ senderPaysFee opt utxo sel = evalStateT (go sel) utxo where
         let coinSel' = CoinSelection
                 { inputs = inps
                 , outputs = outs
-                , change = rebalanceChangeOutputs opt upperBound chgs
+                , change =
+                    rebalanceChangeOutputs (dustThreshold opt) upperBound chgs
                 }
         let remFee = remainingFee opt coinSel'
         -- 3.1/
@@ -270,12 +271,12 @@ coverRemainingFee (Fee fee) = go [] where
 --
 -- We divvy up the fee over all change outputs proportionally, to try and keep
 -- any output:change ratio as unchanged as possible
-rebalanceChangeOutputs :: FeeOptions -> Fee -> [Coin] -> [Coin]
-rebalanceChangeOutputs opt totalFee chgs =
+rebalanceChangeOutputs :: DustThreshold -> Fee -> [Coin] -> [Coin]
+rebalanceChangeOutputs threshold totalFee chgs =
     case filter (> Coin 0) chgs of
         [] -> []
         x : xs ->
-            coalesceDust (dustThreshold opt)
+            coalesceDust threshold
             $ fmap reduceSingleChange
             $ distributeFee totalFee
             $ x :| xs

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -144,7 +144,7 @@ data FeeOptions = FeeOptions
       --     a: 155381 # absolute minimal fees per transaction
       --     b: 43.946 # additional minimal fees per byte of transaction size
     , dustThreshold
-      :: Coin
+      :: DustThreshold
       -- ^ Defines the maximum size of a dust coin.
       --
       -- Change values that are less than or equal to this threshold will be
@@ -401,11 +401,11 @@ distributeFee (Fee feeTotal) coinsUnsafe =
 -- >>> sum coins = sum (coalesceDust threshold coins)
 -- >>> all (/= Coin 0) (coalesceDust threshold coins)
 --
-coalesceDust :: Coin -> NonEmpty Coin -> [Coin]
-coalesceDust threshold coins =
+coalesceDust :: DustThreshold -> NonEmpty Coin -> [Coin]
+coalesceDust (DustThreshold threshold) coins =
     splitChange valueToDistribute coinsToKeep
   where
-    (coinsToKeep, coinsToRemove) = NE.partition (> threshold) coins
+    (coinsToKeep, coinsToRemove) = NE.partition (> Coin threshold) coins
     valueToDistribute = Coin $ sum $ getCoin <$> coinsToRemove
 
 -- | Computes how much is left to pay given a particular selection

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -390,12 +390,10 @@ distributeFee (Fee feeTotal) coinsUnsafe =
 --
 coalesceDust :: Coin -> [Coin] -> [Coin]
 coalesceDust threshold coins =
-    let
-        filtered = L.filter (> threshold) coins
-        diff = balance coins - balance filtered
-            where balance = L.foldl' (\total (Coin c) -> c + total) 0
-    in
-        splitChange (Coin diff) filtered
+    splitChange valueToDistribute coinsToKeep
+  where
+    (coinsToKeep, coinsToRemove) = L.partition (> threshold) coins
+    valueToDistribute = Coin $ sum $ getCoin <$> coinsToRemove
 
 -- | Computes how much is left to pay given a particular selection
 remainingFee

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -32,7 +32,7 @@ module Cardano.Fee
     , adjustForFee
 
       -- * Dust Processing
-    , removeDust
+    , coalesceDust
 
     ) where
 
@@ -256,10 +256,10 @@ coverRemainingFee (Fee fee) = go [] where
 -- any output:change ratio as unchanged as possible
 rebalanceChangeOutputs :: FeeOptions -> Fee -> [Coin] -> [Coin]
 rebalanceChangeOutputs opt totalFee chgs =
-    case removeDust (Coin 0) chgs of
+    case coalesceDust (Coin 0) chgs of
         [] -> []
         x : xs ->
-            removeDust (dustThreshold opt)
+            coalesceDust (dustThreshold opt)
             $ map reduceSingleChange
             $ F.toList
             $ distributeFee totalFee
@@ -383,11 +383,11 @@ distributeFee (Fee feeTotal) coinsUnsafe =
 --
 -- This function satisfies the following properties:
 --
--- >>> sum coins = sum (removeDust threshold coins)
--- >>> all (/= Coin 0) (removeDust threshold coins)
+-- >>> sum coins = sum (coalesceDust threshold coins)
+-- >>> all (/= Coin 0) (coalesceDust threshold coins)
 --
-removeDust :: Coin -> [Coin] -> [Coin]
-removeDust threshold coins =
+coalesceDust :: Coin -> [Coin] -> [Coin]
+coalesceDust threshold coins =
     let
         filtered = L.filter (> threshold) coins
         diff = balance coins - balance filtered

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -32,6 +32,7 @@ module Cardano.Fee
     , adjustForFee
 
       -- * Dust Processing
+    , DustThreshold (..)
     , coalesceDust
 
     ) where
@@ -98,6 +99,17 @@ newtype Fee = Fee
     { getFee :: Word64 }
     deriving stock (Eq, Generic, Ord)
     deriving Show via (Quiet Fee)
+
+-- | Defines the maximum size of a dust coin.
+--
+-- See function 'dustThreshold' within 'FeeOptions'.
+--
+-- This type is isomorphic to 'Coin'.
+--
+newtype DustThreshold = DustThreshold
+    { getDustThreshold :: Word64 }
+    deriving stock (Eq, Generic, Ord)
+    deriving Show via (Quiet DustThreshold)
 
 {-------------------------------------------------------------------------------
                                 Fee Calculation

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -373,11 +373,14 @@ distributeFee (Fee feeTotal) coinsUnsafe =
     totalCoinValue :: Coin
     totalCoinValue = Coin $ F.sum $ getCoin <$> coins
 
--- | Remove coins that are below a given threshold. Note that we can't simply
--- "remove" coins from the list because this could create an unbalanced
--- transaction. Therefore, we want `removeDust` to have the following property:
+-- | From the given list of coins, remove dust coins with a value less than or
+--   equal to the given threshold value, redistributing their total value over
+--   the coins that remain.
 --
---     ∀δ≥0. sum coins == sum (removeDust δcoins)
+-- This function satisfies the following properties:
+--
+-- >>> sum coins = sum (removeDust threshold coins)
+-- >>> all (/= Coin 0) (removeDust threshold coins)
 --
 removeDust :: Coin -> [Coin] -> [Coin]
 removeDust threshold coins =

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -90,7 +90,10 @@ import qualified Data.List.NonEmpty as NE
                                     Types
 -------------------------------------------------------------------------------}
 
--- | A 'Fee', isomorph to 'Coin' but ease type-signatures and readability.
+-- | Represents a fee to be paid on a transaction.
+--
+-- This type is isomorphic to 'Coin'.
+--
 newtype Fee = Fee
     { getFee :: Word64 }
     deriving stock (Eq, Generic, Ord)

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -30,6 +30,10 @@ module Cardano.Fee
     , FeeOptions (..)
     , ErrAdjustForFee(..)
     , adjustForFee
+
+      -- * Dust Processing
+    , removeDust
+
     ) where
 
 import Prelude hiding

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -375,6 +375,8 @@ spec = do
             (checkCoverage propCoalesceDustLeavesNoZeroCoins)
         it "leaves at most one dust coin"
             (checkCoverage propCoalesceDustLeavesAtMostOneDustCoin)
+        it "length coins >= (coalesceDust threshold coins)"
+            (checkCoverage propCoalesceDustNeverLengthensList)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Properties
@@ -627,6 +629,12 @@ propCoalesceDustLeavesAtMostOneDustCoin (CoalesceDustInput threshold coins) =
             Coin (F.sum (getCoin <$> coins)) == x
         xs ->
             all (> threshold) xs
+
+propCoalesceDustNeverLengthensList
+    :: CoalesceDustInput -> Property
+propCoalesceDustNeverLengthensList (CoalesceDustInput threshold coins) =
+    property $
+    length coins >= length (coalesceDust threshold coins)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Unit Tests

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -604,6 +604,9 @@ propCoalesceDustLeavesNoZeroCoins
     :: CoalesceDustInput -> Property
 propCoalesceDustLeavesNoZeroCoins (CoalesceDustInput threshold coins) =
     property $
+    cover 4 (F.all  (== Coin 0) coins) "∀ coin ∈ coins . coin = 0" $
+    cover 4 (F.elem    (Coin 0) coins) "∃ coin ∈ coins . coin = 0" $
+    cover 8 (F.notElem (Coin 0) coins) "∀ coin ∈ coins . coin > 0" $
     notElem (Coin 0) $ coalesceDust threshold coins
 
 propCoalesceDustLeavesAtMostOneDustCoin

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -595,9 +595,10 @@ propCoalesceDustPreservesSum
     :: CoalesceDustInput -> Property
 propCoalesceDustPreservesSum (CoalesceDustInput threshold coins) =
     property $
-    F.sum (getCoin <$> coins)
-    ==
-    F.sum (getCoin <$> coalesceDust threshold coins)
+    let total = sum (getCoin <$> coins) in
+    cover 8 (total == 0) "sum coins = 0" $
+    cover 8 (total /= 0) "sum coins ≠ 0" $
+    total == F.sum (getCoin <$> coalesceDust threshold coins)
 
 propCoalesceDustLeavesNoZeroCoins
     :: CoalesceDustInput -> Property

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -366,6 +366,8 @@ spec = do
     describe "removeDust" $ do
         it "sum coins = sum (removeDust threshold coins)"
             (checkCoverage propRemoveDustPreservesSum)
+        it "all (/= Coin 0) (removeDust threshold coins)"
+            (checkCoverage propRemoveDustNoZeroCoins)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Properties
@@ -561,6 +563,11 @@ propRemoveDustPreservesSum threshold coins = property $
     F.sum (getCoin <$> coins)
     ==
     F.sum (getCoin <$> removeDust threshold coins)
+
+propRemoveDustNoZeroCoins
+    :: Coin -> [Word64] -> Property
+propRemoveDustNoZeroCoins threshold coinValues = property $
+    notElem (Coin 0) $ removeDust threshold (Coin <$> coinValues)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Unit Tests

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -615,25 +615,19 @@ propCoalesceDustLeavesAtMostOneDustCoin
 propCoalesceDustLeavesAtMostOneDustCoin (CoalesceDustInput threshold coins) =
     property $
     let result = coalesceDust threshold coins in
-
     -- Check that we cover different kinds of threshold conditions:
     cover 8 (F.any (>  threshold') coins) "∃ coin ∈ coins . coin < threshold" $
     cover 8 (F.any (<  threshold') coins) "∃ coin ∈ coins . coin > threshold" $
     cover 8 (F.any (== threshold') coins) "∃ coin ∈ coins . coin = threshold" $
     cover 8 (F.all (/= threshold') coins) "∀ coin ∈ coins . coin ≠ threshold" $
-
     -- Check that we cover different result lengths:
     cover 8 (null result)        "length result = 0" $
     cover 8 (length result == 1) "length result = 1" $
     cover 8 (length result >= 2) "length result ≥ 2" $
-
     case result of
-        [] ->
-            F.sum (getCoin <$> coins) == 0
-        [x] ->
-            Coin (F.sum (getCoin <$> coins)) == x
-        xs ->
-            all (> threshold') xs
+        [ ] -> F.sum (getCoin <$> coins) == 0
+        [x] -> Coin (F.sum (getCoin <$> coins)) == x
+        cxs -> all (> threshold') cxs
   where
     threshold' = Coin $ getDustThreshold threshold
 

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -20,7 +20,8 @@ import Cardano.CoinSelection
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.Fee
-    ( ErrAdjustForFee (..)
+    ( DustThreshold (..)
+    , ErrAdjustForFee (..)
     , Fee (..)
     , FeeOptions (..)
     , adjustForFee
@@ -751,6 +752,10 @@ instance Arbitrary TxIn where
 instance Arbitrary Coin where
     shrink (Coin c) = Coin <$> filter (> 0) (shrink $ fromIntegral c)
     arbitrary = Coin <$> choose (1, 200000)
+
+instance Arbitrary DustThreshold where
+    arbitrary = DustThreshold <$> choose (0, 100)
+    shrink = genericShrink
 
 instance Arbitrary Fee where
     shrink (Fee c) = Fee <$> filter (> 0) (shrink $ fromIntegral c)

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -24,6 +24,7 @@ import Cardano.Fee
     , FeeOptions (..)
     , adjustForFee
     , distributeFee
+    , removeDust
     )
 import Cardano.Types
     ( Address (..)
@@ -362,6 +363,10 @@ spec = do
         it "expectFailure: not (any null (fst <$> distributeFee fee outs))"
             (expectFailure propDistributeFeeNoNullFee)
 
+    describe "removeDust" $ do
+        it "sum coins = sum (removeDust threshold coins)"
+            (checkCoverage propRemoveDustPreservesSum)
+
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Properties
 -------------------------------------------------------------------------------}
@@ -545,6 +550,17 @@ propDistributeFeeNoNullFee (fee, outs) =
     not (null outs) ==> withMaxSuccess 100000 prop
   where
     prop = property $ Fee 0 `F.notElem` (fst <$> distributeFee fee outs)
+
+{-------------------------------------------------------------------------------
+                         removeDust - Properties
+-------------------------------------------------------------------------------}
+
+propRemoveDustPreservesSum
+    :: Coin -> [Coin] -> Property
+propRemoveDustPreservesSum threshold coins = property $
+    F.sum (getCoin <$> coins)
+    ==
+    F.sum (getCoin <$> removeDust threshold coins)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Unit Tests

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -23,8 +23,8 @@ import Cardano.Fee
     , Fee (..)
     , FeeOptions (..)
     , adjustForFee
+    , coalesceDust
     , distributeFee
-    , removeDust
     )
 import Cardano.Types
     ( Address (..)
@@ -363,11 +363,11 @@ spec = do
         it "expectFailure: not (any null (fst <$> distributeFee fee outs))"
             (expectFailure propDistributeFeeNoNullFee)
 
-    describe "removeDust" $ do
-        it "sum coins = sum (removeDust threshold coins)"
-            (checkCoverage propRemoveDustPreservesSum)
-        it "all (/= Coin 0) (removeDust threshold coins)"
-            (checkCoverage propRemoveDustNoZeroCoins)
+    describe "coalesceDust" $ do
+        it "sum coins = sum (coalesceDust threshold coins)"
+            (checkCoverage propCoalesceDustPreservesSum)
+        it "all (/= Coin 0) (coalesceDust threshold coins)"
+            (checkCoverage propCoalesceDustNoZeroCoins)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Properties
@@ -554,20 +554,20 @@ propDistributeFeeNoNullFee (fee, outs) =
     prop = property $ Fee 0 `F.notElem` (fst <$> distributeFee fee outs)
 
 {-------------------------------------------------------------------------------
-                         removeDust - Properties
+                         coalesceDust - Properties
 -------------------------------------------------------------------------------}
 
-propRemoveDustPreservesSum
+propCoalesceDustPreservesSum
     :: Coin -> [Coin] -> Property
-propRemoveDustPreservesSum threshold coins = property $
+propCoalesceDustPreservesSum threshold coins = property $
     F.sum (getCoin <$> coins)
     ==
-    F.sum (getCoin <$> removeDust threshold coins)
+    F.sum (getCoin <$> coalesceDust threshold coins)
 
-propRemoveDustNoZeroCoins
+propCoalesceDustNoZeroCoins
     :: Coin -> [Word64] -> Property
-propRemoveDustNoZeroCoins threshold coinValues = property $
-    notElem (Coin 0) $ removeDust threshold (Coin <$> coinValues)
+propCoalesceDustNoZeroCoins threshold coinValues = property $
+    notElem (Coin 0) $ coalesceDust threshold (Coin <$> coinValues)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Unit Tests


### PR DESCRIPTION
## Related Issue

Preparation for #21.

## Summary

This PR:

- [x] **Renames** `removeDust` to `coalesceDust`.
    **Justification**: this function _doesn't_ always succeed at removing all dust, but it _does_ always succeed at coalescing dust to the greatest extent possible.
- [x] **Adds property tests** to check that:
    - [x] `coalesceDust` preserves the _total sum_.
    - [x] `coalesceDust` removes _all_ zero-valued coins.
    - [x] `coalesceDust` leaves behind _at most_ one dust coin.
- [x] **Corrects errors** in the documentation for `coalesceDust` and `dustThreshold`, emphasizing that the dust threshold value defines an _inclusive_ upper limit for dust values, rather than an _exclusive_ upper limit.