### PR TITLE
Generalize Types

### DIFF
--- a/cardano-coin-selection.cabal
+++ b/cardano-coin-selection.cabal
@@ -44,7 +44,6 @@ library
     , cryptonite
     , deepseq
     , fmt
-    , memory
     , quiet
     , text
     , transformers
@@ -78,11 +77,13 @@ test-suite unit
     , cardano-coin-selection
     , containers
     , cryptonite
+    , deepseq
     , fmt
     , hspec
     , memory
     , QuickCheck
     , random
+    , quiet
     , text
     , transformers
     , vector
@@ -101,6 +102,7 @@ test-suite unit
       Cardano.CoinSelectionSpec
       Cardano.FeeSpec
       Cardano.TypesSpec
+      Test.Cardano.Types
       Test.Unsafe
       Test.Vector.Shuffle
       Test.Vector.ShuffleSpec

--- a/src/Cardano/CoinSelection.hs
+++ b/src/Cardano/CoinSelection.hs
@@ -66,7 +66,7 @@ newtype CoinSelectionAlgorithm i u m e = CoinSelectionAlgorithm
 -- See 'CoinSelectionAlgorithm'.
 --
 data CoinSelection i = CoinSelection
-    { inputs :: [(i, TxOut)]
+    { inputs :: [(i, Coin)]
       -- ^ A /subset/ of the original 'UTxO' that was passed to the coin
       -- selection algorithm, containing only the entries that were /selected/
       -- by the coin selection algorithm.
@@ -120,7 +120,7 @@ data CoinSelectionOptions i e = CoinSelectionOptions
 
 -- | Calculate the total sum of all 'inputs' for the given 'CoinSelection'.
 inputBalance :: CoinSelection i -> Word64
-inputBalance =  foldl' (\total -> addTxOut total . snd) 0 . inputs
+inputBalance =  foldl' (\total -> addCoin total . snd) 0 . inputs
 
 -- | Calculate the total sum of all 'outputs' for the given 'CoinSelection'.
 outputBalance :: CoinSelection i -> Word64

--- a/src/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/Cardano/CoinSelection/LargestFirst.hs
@@ -212,7 +212,7 @@ payForOutputs options outputsRequested utxo =
         fromIntegral $ L.length $ (Map.toList . getUTxO) utxo
     utxoDescending =
         take (fromIntegral inputCountMax)
-            $ L.sortOn (Down . coin . snd)
+            $ L.sortOn (Down . snd)
             $ Map.toList
             $ getUTxO utxo
     validateSelection =
@@ -230,18 +230,18 @@ payForOutputs options outputsRequested utxo =
 --
 payForOutput
     :: forall i u . i ~ u
-    => ([(u, TxOut)], CoinSelection i)
+    => ([(u, Coin)], CoinSelection i)
     -> TxOut
-    -> Maybe ([(u, TxOut)], CoinSelection i)
+    -> Maybe ([(u, Coin)], CoinSelection i)
 payForOutput (utxoAvailable, currentSelection) txout =
     let target = fromIntegral $ getCoin $ coin txout in
     coverTarget target utxoAvailable mempty
   where
     coverTarget
         :: Integer
-        -> [(u, TxOut)]
-        -> [(u, TxOut)]
-        -> Maybe ([(u, TxOut)], CoinSelection i)
+        -> [(u, Coin)]
+        -> [(u, Coin)]
+        -> Maybe ([(u, Coin)], CoinSelection i)
     coverTarget target utxoRemaining utxoSelected
         | target <= 0 = Just
             -- We've selected enough to cover the target, so stop here.
@@ -258,7 +258,7 @@ payForOutput (utxoAvailable, currentSelection) txout =
             case utxoRemaining of
                 (i, o):utxoRemaining' ->
                     let utxoSelected' = (i, o):utxoSelected
-                        target' = target - fromIntegral (getCoin (coin o))
+                        target' = target - fromIntegral (getCoin o)
                     in
                     coverTarget target' utxoRemaining' utxoSelected'
                 [] ->

--- a/src/Cardano/CoinSelection/Migration.hs
+++ b/src/Cardano/CoinSelection/Migration.hs
@@ -49,7 +49,7 @@ import Cardano.CoinSelection
 import Cardano.Fee
     ( DustThreshold (..), Fee (..), FeeOptions (..) )
 import Cardano.Types
-    ( Coin (..), TxOut (..), UTxO (..) )
+    ( Coin (..), UTxO (..) )
 import Control.Monad.Trans.State
     ( State, evalState, get, put )
 import Data.List.NonEmpty
@@ -83,7 +83,7 @@ depleteUTxO
 depleteUTxO feeOpts batchSize utxo =
     evalState migrate (Map.toList (getUTxO utxo))
   where
-    migrate :: State [(u, TxOut)] [CoinSelection i]
+    migrate :: State [(u, Coin)] [CoinSelection i]
     migrate = do
         batch <- getNextBatch
         if null batch then
@@ -97,7 +97,7 @@ depleteUTxO feeOpts batchSize utxo =
     -- Construct a provisional 'CoinSelection' from the given selected inputs.
     -- Note that the selection may look a bit weird at first sight as it has
     -- no outputs (we are paying everything to ourselves!).
-    mkCoinSelection :: [(u, TxOut)] -> CoinSelection i
+    mkCoinSelection :: [(u, Coin)] -> CoinSelection i
     mkCoinSelection inps = CoinSelection
         { inputs = inps
         , outputs = []
@@ -107,8 +107,8 @@ depleteUTxO feeOpts batchSize utxo =
         }
       where
         threshold = Coin $ getDustThreshold $ dustThreshold feeOpts
-        noDust :: TxOut -> Maybe Coin
-        noDust (TxOut _ c)
+        noDust :: Coin -> Maybe Coin
+        noDust c
             | c < threshold = Nothing
             | otherwise = Just c
 

--- a/src/Cardano/CoinSelection/RandomImprove.hs
+++ b/src/Cardano/CoinSelection/RandomImprove.hs
@@ -338,7 +338,7 @@ improveSelection (maxN0, selection, utxo0) (inps0, txout) = do
 
 -- | Represents an entry from a 'UTxO' set that has been selected for inclusion
 --   in the set of 'inputs' of a 'CoinSelection'.
-type CoinSelectionInput i = (i, TxOut)
+type CoinSelectionInput i = (i, Coin)
 
 -- | Represents a target range of /total input values/ for a given output.
 --

--- a/src/Cardano/CoinSelection/RandomImprove.hs
+++ b/src/Cardano/CoinSelection/RandomImprove.hs
@@ -27,12 +27,7 @@ import Cardano.CoinSelection
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.Types
-    ( Coin (..)
-    , UTxO (..)
-    , distance
-    , invariant
-    , pickRandom
-    )
+    ( Coin (..), UTxO (..), distance, invariant, pickRandom )
 import Control.Arrow
     ( left )
 import Control.Monad

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -44,7 +44,12 @@ import Prelude hiding
     ( round )
 
 import Cardano.CoinSelection
-    ( CoinSelection (..), Input (..), changeBalance, inputBalance, outputBalance )
+    ( CoinSelection (..)
+    , Input (..)
+    , changeBalance
+    , inputBalance
+    , outputBalance
+    )
 import Cardano.Types
     ( Coin (..)
     , FeePolicy (..)

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -48,7 +48,6 @@ import Cardano.CoinSelection
 import Cardano.Types
     ( Coin (..)
     , FeePolicy (..)
-    , TxOut (..)
     , UTxO (..)
     , balance'
     , invariant
@@ -254,7 +253,7 @@ senderPaysFee opt utxo sel = evalStateT (go sel) utxo where
 coverRemainingFee
     :: (Ord u, MonadRandom m)
     => Fee
-    -> StateT (UTxO u) (ExceptT ErrAdjustForFee m) [(u, TxOut)]
+    -> StateT (UTxO u) (ExceptT ErrAdjustForFee m) [(u, Coin)]
 coverRemainingFee (Fee fee) = go [] where
     go acc
         | balance' acc >= fee =

--- a/src/Cardano/Types.hs
+++ b/src/Cardano/Types.hs
@@ -28,7 +28,6 @@ module Cardano.Types
     -- * UTxO
     , UTxO (..)
     , balance
-    , balance'
     , pickRandom
     , excluding
     , isSubsetOf
@@ -90,9 +89,9 @@ import qualified Data.Text.Encoding as T
 -------------------------------------------------------------------------------}
 
 data TxIn = TxIn
-    { inputId
+    { txinId
         :: !(Hash "Tx")
-    , inputIx
+    , txinIx
         :: !Word32
     } deriving (Show, Generic, Eq, Ord)
 
@@ -100,9 +99,9 @@ instance NFData TxIn
 
 instance Buildable TxIn where
     build txin = mempty
-        <> ordinalF (inputIx txin + 1)
+        <> ordinalF (txinIx txin + 1)
         <> " "
-        <> build (inputId txin)
+        <> build (txinId txin)
 
 data TxOut = TxOut
     { address
@@ -225,11 +224,6 @@ balance =
   where
     fn :: Natural -> Coin -> Natural
     fn tot out = tot + fromIntegral (getCoin out)
-
--- | Compute the balance of a unwrapped UTxO.
-balance' :: Ord u => [(u, Coin)] -> Word64
-balance' =
-    fromIntegral . balance . UTxO . Map.fromList
 
 -- | ins⋪ u
 excluding :: Ord u => UTxO u -> Set u -> UTxO u

--- a/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -28,7 +28,7 @@ import Cardano.CoinSelectionSpec
     , noValidation
     )
 import Cardano.Types
-    ( Address, Coin (..), TxIn, UTxO (..), excluding )
+    ( Coin (..), UTxO (..), excluding )
 import Control.Monad
     ( unless )
 import Control.Monad.Trans.Except
@@ -39,6 +39,8 @@ import Data.Functor.Identity
     ( Identity (runIdentity) )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
+import Test.Cardano.Types
+    ( Address, TxIn )
 import Test.Hspec
     ( Spec, describe, it, shouldSatisfy )
 import Test.QuickCheck

--- a/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -14,6 +14,7 @@ import Cardano.CoinSelection
     , CoinSelectionAlgorithm (..)
     , CoinSelectionOptions (..)
     , ErrCoinSelection (..)
+    , Input (..)
     )
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
@@ -272,11 +273,11 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
     prop (CoinSelection inps _ _) =
         let
             utxo' = (Map.toList . getUTxO) $
-                utxo `excluding` (Set.fromList . map fst $ inps)
+                utxo `excluding` (Set.fromList . map inputId $ inps)
         in unless (L.null utxo') $
-            (getExtremumValue L.minimum inps)
+            (getExtremumValue L.minimum (inputValue <$> inps))
             `shouldSatisfy`
-            (>= (getExtremumValue L.maximum utxo'))
-    getExtremumValue f = f . map (getCoin . snd)
+            (>= (getExtremumValue L.maximum (snd <$> utxo')))
+    getExtremumValue f = f . map getCoin
     selection = runIdentity $ runExceptT $ selectCoins largestFirst
         (CoinSelectionOptions (const 100) noValidation) txOuts utxo

--- a/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -27,7 +27,7 @@ import Cardano.CoinSelectionSpec
     , noValidation
     )
 import Cardano.Types
-    ( Coin (..), TxIn, UTxO (..), excluding )
+    ( Address, Coin (..), TxIn, UTxO (..), excluding )
 import Control.Monad
     ( unless )
 import Control.Monad.Trans.Except
@@ -222,22 +222,22 @@ spec = do
         it "forall (UTxO, NonEmpty TxOut), running algorithm yields exactly \
             \the same result regardless of the way in which requested outputs \
             \are ordered"
-            (property $ propOutputOrderIrrelevant @TxIn)
+            (property $ propOutputOrderIrrelevant @TxIn @Address)
         it "forall (UTxO, NonEmpty TxOut), there's at least as many selected \
             \inputs as there are requested outputs"
-            (property $ propAtLeast @TxIn)
+            (property $ propAtLeast @TxIn @Address)
         it "forall (UTxO, NonEmpty TxOut), for all selected input, there's no \
             \bigger input in the UTxO that is not already in the selected \
             \inputs"
-            (property $ propInputDecreasingOrder @TxIn)
+            (property $ propInputDecreasingOrder @TxIn @Address)
 
 {-------------------------------------------------------------------------------
                                   Properties
 -------------------------------------------------------------------------------}
 
 propOutputOrderIrrelevant
-    :: (Ord u, Show u)
-    => CoinSelProp u
+    :: (Eq o, Show o, Ord u, Show u)
+    => CoinSelProp o u
     -> Property
 propOutputOrderIrrelevant (CoinSelProp utxo txOuts) = monadicIO $ QC.run $ do
     txOutsShuffled <- shuffleNonEmpty txOuts
@@ -252,7 +252,7 @@ propOutputOrderIrrelevant (CoinSelProp utxo txOuts) = monadicIO $ QC.run $ do
 
 propAtLeast
     :: Ord u
-    => CoinSelProp u
+    => CoinSelProp o u
     -> Property
 propAtLeast (CoinSelProp utxo txOuts) =
     isRight selection ==> let Right (s,_) = selection in prop s
@@ -264,7 +264,7 @@ propAtLeast (CoinSelProp utxo txOuts) =
 
 propInputDecreasingOrder
     :: Ord u
-    => CoinSelProp u
+    => CoinSelProp o u
     -> Property
 propInputDecreasingOrder (CoinSelProp utxo txOuts) =
     isRight selection ==> let Right (s,_) = selection in prop s

--- a/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -27,7 +27,7 @@ import Cardano.CoinSelectionSpec
     , noValidation
     )
 import Cardano.Types
-    ( Coin (..), TxIn, TxOut (..), UTxO (..), excluding )
+    ( Coin (..), TxIn, UTxO (..), excluding )
 import Control.Monad
     ( unless )
 import Control.Monad.Trans.Except
@@ -277,6 +277,6 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
             (getExtremumValue L.minimum inps)
             `shouldSatisfy`
             (>= (getExtremumValue L.maximum utxo'))
-    getExtremumValue f = f . map (getCoin . coin . snd)
+    getExtremumValue f = f . map (getCoin . snd)
     selection = runIdentity $ runExceptT $ selectCoins largestFirst
         (CoinSelectionOptions (const 100) noValidation) txOuts utxo

--- a/test/Cardano/CoinSelection/MigrationSpec.hs
+++ b/test/Cardano/CoinSelection/MigrationSpec.hs
@@ -23,7 +23,7 @@ import Cardano.Fee
 import Cardano.FeeSpec
     ()
 import Cardano.Types
-    ( Address, Coin (..), Hash (..), TxIn (..), UTxO (..), balance )
+    ( Coin (..), UTxO (..), balance )
 import Data.ByteString
     ( ByteString )
 import Data.Function
@@ -32,6 +32,8 @@ import Data.Word
     ( Word8 )
 import Numeric.Natural
     ( Natural )
+import Test.Cardano.Types
+    ( Address, Hash (..), TxIn (..) )
 import Test.Hspec
     ( Spec, SpecWith, describe, it, shouldSatisfy )
 import Test.QuickCheck

--- a/test/Cardano/CoinSelection/MigrationSpec.hs
+++ b/test/Cardano/CoinSelection/MigrationSpec.hs
@@ -22,14 +22,7 @@ import Cardano.Fee
 import Cardano.FeeSpec
     ()
 import Cardano.Types
-    ( Address (..)
-    , Coin (..)
-    , Hash (..)
-    , TxIn (..)
-    , TxOut (..)
-    , UTxO (..)
-    , balance
-    )
+    ( Coin (..), Hash (..), TxIn (..), UTxO (..), balance )
 import Data.ByteString
     ( ByteString )
 import Data.Function
@@ -139,10 +132,7 @@ spec = do
                         { inputId = Hash "|\243^\SUBg\242\231\&1\213\203"
                         , inputIx = 2
                         }
-                      , TxOut
-                        { address = Address "ADDR03"
-                        , coin = Coin 2
-                        }
+                      , Coin 2
                       )
                     ]
             property (prop_inputsGreaterThanOutputs feeOpts batchSize utxo)
@@ -285,20 +275,14 @@ genUTxO :: Double -> Coin -> Gen (UTxO TxIn)
 genUTxO r (Coin dust) = do
     n <- choose (10, 1000)
     inps <- genTxIn n
-    outs <- genTxOut n
-    pure $ UTxO $ Map.fromList $ zip inps outs
+    coins <- vectorOf n genCoin
+    pure $ UTxO $ Map.fromList $ zip inps coins
   where
     genTxIn :: Int -> Gen [TxIn]
     genTxIn n = do
         ids <- vectorOf n (Hash <$> genBytes 8)
         ixs <- vectorOf n arbitrary
         pure $ zipWith TxIn ids ixs
-
-    genTxOut :: Int -> Gen [TxOut]
-    genTxOut n = do
-        coins <- vectorOf n genCoin
-        addrs <- vectorOf n (Address <$> genBytes 8)
-        pure $ zipWith TxOut addrs coins
 
     genBytes :: Int -> Gen ByteString
     genBytes n = B8.pack <$> vectorOf n arbitrary

--- a/test/Cardano/CoinSelection/MigrationSpec.hs
+++ b/test/Cardano/CoinSelection/MigrationSpec.hs
@@ -13,7 +13,7 @@ module Cardano.CoinSelection.MigrationSpec
 import Prelude
 
 import Cardano.CoinSelection
-    ( CoinSelection (..), changeBalance, inputBalance )
+    ( CoinSelection (..), Input (..), changeBalance, inputBalance )
 import Cardano.CoinSelection.Migration
     ( depleteUTxO, idealBatchSize )
 import Cardano.CoinSelectionSpec
@@ -130,8 +130,8 @@ spec = do
             let batchSize = 1
             let utxo = UTxO $ Map.fromList
                     [ ( TxIn
-                        { inputId = Hash "|\243^\SUBg\242\231\&1\213\203"
-                        , inputIx = 2
+                        { txinId = Hash "|\243^\SUBg\242\231\&1\213\203"
+                        , txinIx = 2
                         }
                       , Coin 2
                       )
@@ -213,7 +213,7 @@ prop_inputsStillInUTxO feeOpts batchSize utxo = do
             Set.fromList $ inputs =<<
                 depleteUTxO feeOpts batchSize utxo
     let utxoSet =
-            Set.fromList $ Map.toList $ getUTxO utxo
+            Set.fromList $ fmap (uncurry Input) $ Map.toList $ getUTxO utxo
     property (selectionInputSet `Set.isSubsetOf` utxoSet)
 
 -- | Every coin selection is well-balanced (i.e. actual fees are exactly the

--- a/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.CoinSelection.RandomImproveSpec
@@ -27,6 +28,8 @@ import Cardano.CoinSelectionSpec
     , coinSelectionUnitTest
     , noValidation
     )
+import Cardano.Types
+    ( TxIn )
 import Control.Monad.Trans.Except
     ( runExceptT )
 import Crypto.Random
@@ -234,18 +237,19 @@ spec = do
         describe "Coin selection properties : random algorithm" $ do
             it "forall (UTxO, NonEmpty TxOut), running algorithm gives not \
                 \less UTxO fragmentation than LargestFirst algorithm"
-                (property . propFragmentation)
+                (property . propFragmentation @TxIn)
             it "forall (UTxO, NonEmpty TxOut), running algorithm gives the \
                 \same errors as LargestFirst algorithm"
-                (property . propErrors)
+                (property . propErrors @TxIn)
 
 {-------------------------------------------------------------------------------
                               Properties
 -------------------------------------------------------------------------------}
 
 propFragmentation
-    :: SystemDRG
-    -> CoinSelProp
+    :: Ord u
+    => SystemDRG
+    -> CoinSelProp u
     -> Property
 propFragmentation drg (CoinSelProp utxo txOuts) = do
     isRight selection1 && isRight selection2 ==>
@@ -262,8 +266,9 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
     opt = CoinSelectionOptions (const 100) noValidation
 
 propErrors
-    :: SystemDRG
-    -> CoinSelProp
+    :: Ord u
+    => SystemDRG
+    -> CoinSelProp u
     -> Property
 propErrors drg (CoinSelProp utxo txOuts) = do
     isLeft selection1 && isLeft selection2 ==>

--- a/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -28,8 +28,6 @@ import Cardano.CoinSelectionSpec
     , coinSelectionUnitTest
     , noValidation
     )
-import Cardano.Types
-    ( Address, TxIn )
 import Control.Monad.Trans.Except
     ( runExceptT )
 import Crypto.Random
@@ -42,6 +40,8 @@ import Data.Functor.Identity
     ( Identity (..) )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
+import Test.Cardano.Types
+    ( Address, TxIn )
 import Test.Hspec
     ( Spec, before, describe, it, shouldSatisfy )
 import Test.QuickCheck

--- a/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -29,7 +29,7 @@ import Cardano.CoinSelectionSpec
     , noValidation
     )
 import Cardano.Types
-    ( TxIn )
+    ( Address, TxIn )
 import Control.Monad.Trans.Except
     ( runExceptT )
 import Crypto.Random
@@ -237,10 +237,10 @@ spec = do
         describe "Coin selection properties : random algorithm" $ do
             it "forall (UTxO, NonEmpty TxOut), running algorithm gives not \
                 \less UTxO fragmentation than LargestFirst algorithm"
-                (property . propFragmentation @TxIn)
+                (property . propFragmentation @TxIn @Address)
             it "forall (UTxO, NonEmpty TxOut), running algorithm gives the \
                 \same errors as LargestFirst algorithm"
-                (property . propErrors @TxIn)
+                (property . propErrors @TxIn @Address)
 
 {-------------------------------------------------------------------------------
                               Properties
@@ -249,7 +249,7 @@ spec = do
 propFragmentation
     :: Ord u
     => SystemDRG
-    -> CoinSelProp u
+    -> CoinSelProp o u
     -> Property
 propFragmentation drg (CoinSelProp utxo txOuts) = do
     isRight selection1 && isRight selection2 ==>
@@ -268,7 +268,7 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
 propErrors
     :: Ord u
     => SystemDRG
-    -> CoinSelProp u
+    -> CoinSelProp o u
     -> Property
 propErrors drg (CoinSelProp utxo txOuts) = do
     isLeft selection1 && isLeft selection2 ==>

--- a/test/Cardano/CoinSelectionSpec.hs
+++ b/test/Cardano/CoinSelectionSpec.hs
@@ -36,13 +36,7 @@ import Cardano.CoinSelection
     , Output (..)
     )
 import Cardano.Types
-    ( Address (..)
-    , Coin (..)
-    , Hash (..)
-    , ShowFmt (..)
-    , TxIn (..)
-    , UTxO (..)
-    )
+    ( Coin (..), ShowFmt (..), UTxO (..) )
 import Control.Monad.Trans.Except
     ( runExceptT )
 import Data.List.NonEmpty
@@ -53,6 +47,8 @@ import Data.Word
     ( Word64, Word8 )
 import Fmt
     ( Buildable (..), blockListF, nameF )
+import Test.Cardano.Types
+    ( Address (..), Hash (..), TxIn (..) )
 import Test.Hspec
     ( Spec, SpecWith, describe, it, shouldBe )
 import Test.QuickCheck

--- a/test/Cardano/CoinSelectionSpec.hs
+++ b/test/Cardano/CoinSelectionSpec.hs
@@ -163,7 +163,7 @@ coinSelectionUnitTest alg lbl expected (CoinSelectionFixture n fn utxoF outsF) =
             (CoinSelection inps outs chngs, _) <-
                 selectCoins alg (CoinSelectionOptions (const n) fn) txOuts utxo
             return $ CoinSelectionResult
-                { rsInputs = map (getCoin . coin . snd) inps
+                { rsInputs = map (getCoin . snd) inps
                 , rsChange = map getCoin chngs
                 , rsOutputs = map (getCoin . coin) outs
                 }
@@ -262,8 +262,7 @@ genUTxO :: (Arbitrary u, Ord u) => [Word64] -> Gen (UTxO u)
 genUTxO coins = do
     let n = length coins
     inps <- vectorOf n arbitrary
-    outs <- genTxOut coins
-    return $ UTxO $ Map.fromList $ zip inps outs
+    return $ UTxO $ Map.fromList $ zip inps (Coin <$> coins)
 
 genTxOut :: [Word64] -> Gen [TxOut]
 genTxOut coins = do

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -36,13 +36,7 @@ import Cardano.Fee
     , rebalanceChangeOutputs
     )
 import Cardano.Types
-    ( Address (..)
-    , Coin (..)
-    , Hash (..)
-    , ShowFmt (..)
-    , TxIn (..)
-    , UTxO (..)
-    )
+    ( Coin (..), ShowFmt (..), UTxO (..) )
 import Control.Arrow
     ( left )
 import Control.Monad
@@ -73,6 +67,8 @@ import GHC.Generics
     ( Generic )
 import Numeric.Rounding
     ( RoundingDirection (..), round )
+import Test.Cardano.Types
+    ( Address (..), Hash (..), TxIn (..) )
 import Test.Hspec
     ( Spec, SpecWith, before, describe, it, shouldBe, shouldSatisfy )
 import Test.QuickCheck

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -399,7 +399,7 @@ isValidSelection (CoinSelection i o c) =
     let
         oAmt = sum $ map (fromIntegral . getCoin . coin) o
         cAmt = sum $ map (fromIntegral . getCoin) c
-        iAmt = sum $ map (fromIntegral . getCoin . coin . snd) i
+        iAmt = sum $ map (fromIntegral . getCoin . snd) i
     in
         (iAmt :: Integer) >= (oAmt + cAmt)
 
@@ -729,7 +729,7 @@ feeUnitTest (FeeFixture inpsF outsF chngsF utxoF feeF dustF) expected =
             (CoinSelection inps outs chngs) <-
                 adjustForFee (feeOptions feeF dustF) utxo sel
             return $ FeeOutput
-                { csInps = map (getCoin . coin . snd) inps
+                { csInps = map (getCoin . snd) inps
                 , csOuts = map (getCoin . coin) outs
                 , csChngs = map getCoin chngs
                 }
@@ -791,8 +791,7 @@ genUTxO
 genUTxO coins = do
     let n = length coins
     inps <- vectorOf n arbitrary
-    outs <- genTxOut coins
-    return $ UTxO $ Map.fromList $ zip inps outs
+    return $ UTxO $ Map.fromList $ zip inps coins
 
 genTxOut :: [Coin] -> Gen [TxOut]
 genTxOut coins = do

--- a/test/Cardano/TypesSpec.hs
+++ b/test/Cardano/TypesSpec.hs
@@ -13,13 +13,9 @@ module Cardano.TypesSpec
 import Prelude
 
 import Cardano.Types
-    ( Address (..)
-    , Coin (..)
+    ( Coin (..)
     , Dom (..)
-    , Hash (..)
     , ShowFmt (..)
-    , TxIn (..)
-    , TxOut (..)
     , UTxO (..)
     , balance
     , excluding
@@ -30,6 +26,8 @@ import Cardano.Types
     )
 import Data.Set
     ( Set, (\\) )
+import Test.Cardano.Types
+    ( Address (..), Hash (..), TxIn (..), TxOut (..) )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck

--- a/test/Cardano/TypesSpec.hs
+++ b/test/Cardano/TypesSpec.hs
@@ -99,7 +99,7 @@ prop_2_1_2 (ins, u) =
     cond = not $ Set.null $ dom u `Set.intersection` ins
     prop = (u `excluding` ins) `isSubsetOf` u
 
-prop_2_1_3 :: Ord u => (Set TxOut, UTxO u) -> Property
+prop_2_1_3 :: Ord u => (Set Coin, UTxO u) -> Property
 prop_2_1_3 (outs, u) =
     cover 50 cond "u ⋂ outs ≠ ∅" (property prop)
   where

--- a/test/Cardano/TypesSpec.hs
+++ b/test/Cardano/TypesSpec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.TypesSpec
@@ -56,49 +57,49 @@ spec = do
 
     describe "Lemma 2.1 - Properties of UTxO operations" $ do
         it "2.1.1) ins⊲ u ⊆ u"
-            (checkCoverage prop_2_1_1)
+            (checkCoverage $ prop_2_1_1 @TxIn)
         it "2.1.2) ins⋪ u ⊆ u"
-            (checkCoverage prop_2_1_2)
+            (checkCoverage $ prop_2_1_2 @TxIn)
         it "2.1.3) u ⊳ outs ⊆ u"
-            (checkCoverage prop_2_1_3)
+            (checkCoverage $ prop_2_1_3 @TxIn)
         it "2.1.4) ins⊲ (u ⋃ v) = (ins⊲ u) ⋃ (ins⊲ v)"
-            (checkCoverage prop_2_1_4)
+            (checkCoverage $ prop_2_1_4 @TxIn)
         it "2.1.5) ins⋪ (u ⋃ v) = (ins⋪ u) ⋃ (ins⋪ v)"
-            (checkCoverage prop_2_1_5)
+            (checkCoverage $ prop_2_1_5 @TxIn)
         it "2.1.6) (dom u ⋂ ins) ⊲ u = ins⊲ u"
-            (checkCoverage prop_2_1_6)
+            (checkCoverage $ prop_2_1_6 @TxIn)
         it "2.1.7) (dom u ⋂ ins) ⋪ u = ins⋪ u"
-            (checkCoverage prop_2_1_7)
+            (checkCoverage $ prop_2_1_7 @TxIn)
         it "2.1.8) (dom u ⋃ ins) ⋪ (u ⋃ v) = (ins ⋃ dom u) ⋪ v"
-            (checkCoverage prop_2_1_8)
+            (checkCoverage $ prop_2_1_8 @TxIn)
         it "2.1.9) ins⋪ u = (dom u \\ ins)⊲ u"
-            (checkCoverage prop_2_1_9)
+            (checkCoverage $ prop_2_1_9 @TxIn)
 
     describe "Lemma 2.6 - Properties of balance" $ do
         it "2.6.1) dom u ⋂ dom v ==> balance (u ⋃ v) = balance u + balance v"
-            (checkCoverage prop_2_6_1)
+            (checkCoverage $ prop_2_6_1 @TxIn)
         it "2.6.2) balance (ins⋪ u) = balance u - balance (ins⊲ u)"
-            (checkCoverage prop_2_6_2)
+            (checkCoverage $ prop_2_6_2 @TxIn)
 
 {-------------------------------------------------------------------------------
        Wallet Specification - Lemma 2.1 - Properties of UTxO operations
 -------------------------------------------------------------------------------}
 
-prop_2_1_1 :: (Set TxIn, UTxO) -> Property
+prop_2_1_1 :: Ord u => (Set u, UTxO u) -> Property
 prop_2_1_1 (ins, u) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
     cond = not $ Set.null $ dom u `Set.intersection` ins
     prop = (u `restrictedBy` ins) `isSubsetOf` u
 
-prop_2_1_2 :: (Set TxIn, UTxO) -> Property
+prop_2_1_2 :: Ord u => (Set u, UTxO u) -> Property
 prop_2_1_2 (ins, u) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
     cond = not $ Set.null $ dom u `Set.intersection` ins
     prop = (u `excluding` ins) `isSubsetOf` u
 
-prop_2_1_3 :: (Set TxOut, UTxO) -> Property
+prop_2_1_3 :: Ord u => (Set TxOut, UTxO u) -> Property
 prop_2_1_3 (outs, u) =
     cover 50 cond "u ⋂ outs ≠ ∅" (property prop)
   where
@@ -106,7 +107,7 @@ prop_2_1_3 (outs, u) =
         Set.fromList (Map.elems (getUTxO u)) `Set.intersection` outs
     prop = (u `restrictedTo` outs) `isSubsetOf` u
 
-prop_2_1_4 :: (Set TxIn, UTxO, UTxO) -> Property
+prop_2_1_4 :: (Ord u, Show u) => (Set u, UTxO u, UTxO u) -> Property
 prop_2_1_4 (ins, u, v) =
     cover 50 cond "(dom u ⋃ dom v) ⋂ ins ≠ ∅" (property prop)
   where
@@ -116,7 +117,7 @@ prop_2_1_4 (ins, u, v) =
             ===
         (u `restrictedBy` ins) <> (v `restrictedBy` ins)
 
-prop_2_1_5 :: (Set TxIn, UTxO, UTxO) -> Property
+prop_2_1_5 :: (Ord u, Show u) => (Set u, UTxO u, UTxO u) -> Property
 prop_2_1_5 (ins, u, v) =
     cover 50 cond "(dom u ⋃ dom v) ⋂ ins ≠ ∅" (property prop)
   where
@@ -126,7 +127,7 @@ prop_2_1_5 (ins, u, v) =
             ===
         (u `excluding` ins) <> (v `excluding` ins)
 
-prop_2_1_6 :: (Set TxIn, UTxO) -> Property
+prop_2_1_6 :: (Ord u, Show u) => (Set u, UTxO u) -> Property
 prop_2_1_6 (ins, u) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
@@ -136,7 +137,7 @@ prop_2_1_6 (ins, u) =
             ===
         (u `restrictedBy` ins)
 
-prop_2_1_7 :: (Set TxIn, UTxO) -> Property
+prop_2_1_7 :: (Ord u, Show u) => (Set u, UTxO u) -> Property
 prop_2_1_7 (ins, u) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
@@ -146,7 +147,7 @@ prop_2_1_7 (ins, u) =
             ===
         (u `excluding` ins)
 
-prop_2_1_8 :: (Set TxIn, UTxO, UTxO) -> Property
+prop_2_1_8 :: (Ord u, Show u) => (Set u, UTxO u, UTxO u) -> Property
 prop_2_1_8 (ins, u, v) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
@@ -156,7 +157,7 @@ prop_2_1_8 (ins, u, v) =
             ===
         v `excluding` (ins <> dom u)
 
-prop_2_1_9 :: (Set TxIn, UTxO) -> Property
+prop_2_1_9 :: (Ord u, Show u) => (Set u, UTxO u) -> Property
 prop_2_1_9 (ins, u) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
@@ -167,7 +168,7 @@ prop_2_1_9 (ins, u) =
        Wallet Specification - Lemma 2.6 - Properties of Balance
 -------------------------------------------------------------------------------}
 
-prop_2_6_1 :: (UTxO, UTxO) -> Property
+prop_2_6_1 :: Ord u => (UTxO u, UTxO u) -> Property
 prop_2_6_1 (u, v) =
     cover 50 cond "u ≠ ∅ , v ≠ ∅" (property prop)
   where
@@ -179,7 +180,7 @@ prop_2_6_1 (u, v) =
     cond = not (u `isSubsetOf` mempty || v' `isSubsetOf` mempty)
     prop = balance (u <> v') === balance u + balance v'
 
-prop_2_6_2 :: (Set TxIn, UTxO) -> Property
+prop_2_6_2 :: Ord u => (Set u, UTxO u) -> Property
 prop_2_6_2 (ins, u) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
@@ -235,7 +236,7 @@ instance Arbitrary TxIn where
         <$> arbitrary
         <*> scale (`mod` 3) arbitrary -- No need for a crazy high indexes
 
-instance Arbitrary UTxO where
+instance (Arbitrary u, Ord u) => Arbitrary (UTxO u) where
     shrink (UTxO utxo) = UTxO <$> shrink utxo
     arbitrary = do
         n <- choose (0, 10)

--- a/test/Test/Cardano/Types.hs
+++ b/test/Test/Cardano/Types.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Utility types used purely for testing.
+--
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+module Test.Cardano.Types
+    (
+    -- * Addresses
+      Address (..)
+
+    -- * Hashes
+    , Hash (..)
+
+    -- * Transactions
+    , TxIn (..)
+    , TxOut (..)
+
+    ) where
+
+import Prelude
+
+import Cardano.Types
+    ( Coin (..) )
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.ByteArray
+    ( ByteArrayAccess )
+import Data.ByteArray.Encoding
+    ( Base (Base16), convertToBase )
+import Data.ByteString
+    ( ByteString )
+import Data.Word
+    ( Word32 )
+import Fmt
+    ( Buildable (..), ordinalF, prefixF, suffixF )
+import GHC.Generics
+    ( Generic )
+import GHC.TypeLits
+    ( Symbol )
+import Quiet
+    ( Quiet (Quiet) )
+
+import qualified Data.Text.Encoding as T
+
+{-------------------------------------------------------------------------------
+                                  Addresses
+-------------------------------------------------------------------------------}
+
+newtype Address = Address
+    { unAddress :: ByteString }
+    deriving stock (Eq, Generic, Ord)
+    deriving Show via (Quiet Address)
+
+instance NFData Address
+
+instance Buildable Address where
+    build addr = mempty
+        <> prefixF 8 addrF
+        <> "..."
+        <> suffixF 8 addrF
+      where
+        addrF = build (toText addr)
+        toText = T.decodeUtf8
+            . convertToBase Base16
+            . unAddress
+
+{-------------------------------------------------------------------------------
+                                   Hashes
+-------------------------------------------------------------------------------}
+
+newtype Hash (tag :: Symbol) = Hash { getHash :: ByteString }
+    deriving stock (Eq, Generic, Ord)
+    deriving newtype (ByteArrayAccess)
+    deriving Show via (Quiet (Hash tag))
+
+instance NFData (Hash tag)
+
+instance Buildable (Hash tag) where
+    build h = mempty
+        <> prefixF 8 builder
+      where
+        builder = build . toText $ h
+        toText = T.decodeUtf8 . convertToBase Base16 . getHash
+
+{-------------------------------------------------------------------------------
+                                Transactions
+-------------------------------------------------------------------------------}
+
+data TxIn = TxIn
+    { txinId
+        :: !(Hash "Tx")
+    , txinIx
+        :: !Word32
+    } deriving (Show, Generic, Eq, Ord)
+
+instance NFData TxIn
+
+instance Buildable TxIn where
+    build txin = mempty
+        <> ordinalF (txinIx txin + 1)
+        <> " "
+        <> build (txinId txin)
+
+data TxOut = TxOut
+    { address
+        :: !Address
+    , coin
+        :: !Coin
+    } deriving (Show, Generic, Eq, Ord)
+
+instance NFData TxOut
+
+instance Buildable TxOut where
+    build txout = mempty
+        <> build (coin txout)
+        <> " @ "
+        <> prefixF 8 addrF
+        <> "..."
+        <> suffixF 8 addrF
+      where
+        addrF = build $ address txout


### PR DESCRIPTION
## Related Issues

#16
#17

## Summary

This PR generalizes the following types, removing everything that is not necessary for coin selection:

* [`UTxO`](#utxo)
* [`CoinSelection`](#coin-selection)
* [`CoinSelectionAlgorithm`](#coin-selection-algorithm)
* [`CoinSelectionOptions`](#coin-selection-options)

The following types are no longer part of the public API:

* `Address`
* `Hash`
* `TxIn`
* `TxOut`

## Type Variables

This PR introduces a standard set of type variables:

| Type Variable | Meaning |
|--|--|
| **`i`** | a unique identifier for a _coin selection input_. |
| **`o`** | a unique identifier for a _coin selection output_. |
| **`u`** | a unique identifier for an _unspent transaction output_. |

## Details

#### <a href='#utxo' id = 'utxo' class='anchor'>`UTxO`</a>

```patch
- newtype UTxO   = UTxO { getUTxO :: Map TxIn TxOut }
+ newtype UTxO u = UTxO { getUTxO :: Map u    Coin  }
```

#### <a href='#coin-selection' id='coin-selection' class='anchor'>`CoinSelection`</a>

```patch
- data CoinSelection     = CoinSelection
+ data CoinSelection i o = CoinSelection
-     { inputs  :: [(TxIn, TxOut)]
-     , outputs :: [       TxOut ]
+     { inputs  :: [Input  i]
+     , outputs :: [Output o]
      , change  :: [Coin]
      }

+ data  Input i =  Input { inputId :: i,  inputValue :: Coin}
+ data Output o = Output {outputId :: o, outputValue :: Coin}
```

#### <a href='#coin-selection-algorithm' id='coin-selection-algorithm' class='anchor'>`CoinSelectionAlgorithm`</a>

```patch
- newtype CoinSelectionAlgorithm       m e = CoinSelectionAlgorithm
+ newtype CoinSelectionAlgorithm i o u m e = CoinSelectionAlgorithm
      { selectCoins
-         :: CoinSelectionOptions     e
+         :: i ~ u
+         => CoinSelectionOptions i o e
-         -> NonEmpty TxOut
+         -> NonEmpty (Output o)
-         -> UTxO
+         -> UTxO u
-         -> ExceptT (ErrCoinSelection e) m (CoinSelection    , UTxO  )
+         -> ExceptT (ErrCoinSelection e) m (CoinSelection i o, UTxO u)
      }
```
Since each coin selection input **`i`** is actually a _reference_ to an unspent transaction output **`u`**, the types **`i`** and **`u`** are _equivalent_ in this interface.

#### <a href='#coin-selection-options' id='coin-selection-options' class='anchor'>`CoinSelectionOptions`</a>

```patch
- data CoinSelectionOptions     e = CoinSelectionOptions
+ data CoinSelectionOptions i o e = CoinSelectionOptions
      { maximumInputCount :: Word8 -> Word8
-     , validate          :: CoinSelection    -> Either e ()
+     , validate          :: CoinSelection i o-> Either e ()
      }
```