### PR TITLE
Clarify documentation and properties of `splitCoin`. 

### DIFF
--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -36,6 +36,9 @@ module Cardano.Fee
     , DustThreshold (..)
     , coalesceDust
 
+      -- * Coin Splitting
+    , splitCoin
+
     ) where
 
 import Prelude hiding
@@ -455,6 +458,12 @@ remainingFee opts s = do
 -- [Coin 45000000000000000, Coin 1]
 -- >>> splitCoin (Coin 10) (Coin <$> [45000000000000000 - 1])
 -- [Coin 44999999999999999, Coin 10]
+--
+-- == Properties
+--
+-- The total value is preserved:
+--
+-- >>> sum (splitCoin x ys) = x + sum ys
 --
 splitCoin :: Coin -> [Coin] -> [Coin]
 splitCoin = go

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -218,7 +218,7 @@ senderPaysFee opt utxo sel = evalStateT (go sel) utxo where
             -- change plus the extra change brought up by this entry and see if
             -- we can now correctly cover fee.
             inps' <- coverRemainingFee remFee
-            let extraChange = splitChange (Coin $ sumInputs inps') chgs
+            let extraChange = splitCoin (Coin $ sumInputs inps') chgs
             go $ CoinSelection (inps <> inps') outs extraChange
 
 -- | A short / simple version of the 'random' fee policy to cover for fee in
@@ -377,7 +377,7 @@ distributeFee (Fee feeTotal) coinsUnsafe =
 --
 coalesceDust :: DustThreshold -> NonEmpty Coin -> [Coin]
 coalesceDust (DustThreshold threshold) coins =
-    splitChange valueToDistribute coinsToKeep
+    splitCoin valueToDistribute coinsToKeep
   where
     (coinsToKeep, coinsToRemove) = NE.partition (> Coin threshold) coins
     valueToDistribute = Coin $ sum $ getCoin <$> coinsToRemove
@@ -422,9 +422,9 @@ remainingFee opts s = do
 --
 -- == Examples
 --
--- >>> splitChange (Coin 4) (Coin <$> [1, 1, 1, 1])
+-- >>> splitCoin (Coin 4) (Coin <$> [1, 1, 1, 1])
 -- [Coin 2, Coin 2, Coin 2, Coin 2]
--- >>> splitChange (Coin 4) (Coin <$> [1, 2, 3, 4])
+-- >>> splitCoin (Coin 4) (Coin <$> [1, 2, 3, 4])
 -- [Coin 2, Coin 3, Coin 4, Coin 5]
 --
 -- == Special Cases
@@ -432,9 +432,9 @@ remainingFee opts s = do
 -- If given list is /empty/, this function will return a singleton list that
 -- contains /just/ the given coin:
 --
--- >>> splitChange (Coin 1) []
+-- >>> splitCoin (Coin 1) []
 -- [Coin 1]
--- >>> splitChange (Coin 10) []
+-- >>> splitCoin (Coin 10) []
 -- [Coin 10]
 --
 -- While processing the list, if increasing the value of any given coin 'c'
@@ -442,22 +442,22 @@ remainingFee opts s = do
 -- function will leave the coin 'c' unchanged in the resulting list,
 -- distributing the excess value to coins not yet processed:
 --
--- >>> splitChange (Coin 1) (Coin <$> [45000000000000000, 1])
+-- >>> splitCoin (Coin 1) (Coin <$> [45000000000000000, 1])
 -- [Coin 45000000000000000, Coin 2]
--- >>> splitChange (Coin 10) (Coin <$> [45000000000000000 - 1, 1])
+-- >>> splitCoin (Coin 10) (Coin <$> [45000000000000000 - 1, 1])
 -- [Coin 44999999999999999, Coin 11]
 --
 -- After processing the list, if there is any remaining value left over due to
 -- overflow, a new coin is appended to the end of the list to hold the excess
 -- value:
 --
--- >>> splitChange (Coin 1) (Coin <$> [45000000000000000])
+-- >>> splitCoin (Coin 1) (Coin <$> [45000000000000000])
 -- [Coin 45000000000000000, Coin 1]
--- >>> splitChange (Coin 10) (Coin <$> [45000000000000000 - 1])
+-- >>> splitCoin (Coin 10) (Coin <$> [45000000000000000 - 1])
 -- [Coin 44999999999999999, Coin 10]
 --
-splitChange :: Coin -> [Coin] -> [Coin]
-splitChange = go
+splitCoin :: Coin -> [Coin] -> [Coin]
+splitCoin = go
   where
     go remaining as | remaining == Coin 0 = as
     go remaining [] = [remaining]

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -424,8 +424,8 @@ remainingFee opts s = do
 --
 -- == Basic Examples
 --
--- In normal circumstances, each coin value is increased by the same rational
--- amount (modulo rounding):
+-- When it's possible to divide a coin evenly, each coin value is increased by
+-- the same integer amount:
 --
 -- >>> splitCoin (Coin 40) (Coin <$> [1, 1, 1, 1])
 -- [Coin 11, Coin 11, Coin 11, Coin 11]

--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -419,9 +419,8 @@ remainingFee opts s = do
 
 -- | Splits up the given coin of value __@v@__, distributing its value over the
 --   given coin list of length __@n@__, so that each coin value is increased by
---   the same absolute rational amount __@v/n@__ and then rounded to the nearest
---   integer, producing a new list of coin values where the overall total is
---   preserved.
+--   an integral amount within unity of __@v/n@__, producing a new list of coin
+--   values where the overall total is preserved.
 --
 -- == Basic Examples
 --
@@ -433,6 +432,17 @@ remainingFee opts s = do
 --
 -- >>> splitCoin (Coin 40) (Coin <$> [1, 2, 3, 4])
 -- [Coin 11, Coin 12, Coin 13, Coin 14]
+--
+-- == Handling Non-Uniform Increases
+--
+-- When it's not possible to divide a coin evenly, each integral coin value in
+-- the resulting list is always within unity of the ideal unrounded result:
+--
+-- >>> splitCoin (Coin 2) (Coin <$> [1, 1, 1, 1])
+-- [Coin 1, Coin 1, Coin 2, Coin 2]
+--
+-- >>> splitCoin (Coin 10) (Coin <$> [1, 1, 1, 1])
+-- [Coin 3, Coin 3, Coin 4, Coin 4]
 --
 -- == Handling Overflow
 --

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -395,6 +395,8 @@ spec = do
             (checkCoverage propSplitCoinDataCoverage)
         it "data generation is valid"
             (checkCoverage propSplitCoinDataGenerationValid)
+        it "data shrinking is valid"
+            (checkCoverage propSplitCoinDataShrinkingValid)
         it "preserves the total sum"
             (checkCoverage propSplitCoinPreservesSum)
         it "produces only valid coins"
@@ -752,6 +754,7 @@ instance Arbitrary SplitCoinData where
                 , pred . getCoin $ maxBound
                 )
             ]
+    shrink = genericShrink
 
 propSplitCoinDataCoverage :: SplitCoinData -> Property
 propSplitCoinDataCoverage (SplitCoinData coinToSplit coinsToIncrease) =
@@ -788,6 +791,12 @@ propSplitCoinDataCoverage (SplitCoinData coinToSplit coinsToIncrease) =
 propSplitCoinDataGenerationValid :: SplitCoinData -> Property
 propSplitCoinDataGenerationValid scd = property $
     all isValidCoin (scdCoinToSplit scd : scdCoinsToIncrease scd)
+
+propSplitCoinDataShrinkingValid :: SplitCoinData -> Property
+propSplitCoinDataShrinkingValid scd = property $
+    all isValidData (shrink scd)
+  where
+    isValidData d = all isValidCoin (scdCoinToSplit d : scdCoinsToIncrease d)
 
 propSplitCoinPreservesSum :: SplitCoinData -> Property
 propSplitCoinPreservesSum (SplitCoinData coinToSplit coinsToIncrease) =

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -34,6 +34,7 @@ import Cardano.Fee
     , coalesceDust
     , distributeFee
     , rebalanceChangeOutputs
+    , splitCoin
     )
 import Cardano.Types
     ( Coin (..), ShowFmt (..), UTxO (..) )
@@ -392,6 +393,8 @@ spec = do
     describe "splitCoin" $ do
         it "data coverage is adequate"
             (checkCoverage propSplitCoinDataCoverage)
+        it "preserves the total sum"
+            (checkCoverage propSplitCoinPreservesSum)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Properties
@@ -777,6 +780,13 @@ propSplitCoinDataCoverage (SplitCoinData coinToSplit coinsToIncrease) =
         if count == 0
         then getCoin coinToSplit
         else getCoin coinToSplit `div` fromIntegral count
+
+propSplitCoinPreservesSum :: SplitCoinData -> Property
+propSplitCoinPreservesSum (SplitCoinData coinToSplit coinsToIncrease) =
+    property $ totalBefore `shouldBe` totalAfter
+  where
+    totalAfter = sum (getCoin <$> splitCoin coinToSplit coinsToIncrease)
+    totalBefore = getCoin coinToSplit + sum (getCoin <$> coinsToIncrease)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Unit Tests

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -393,6 +393,8 @@ spec = do
     describe "splitCoin" $ do
         it "data coverage is adequate"
             (checkCoverage propSplitCoinDataCoverage)
+        it "data generation is valid"
+            (checkCoverage propSplitCoinDataGenerationValid)
         it "preserves the total sum"
             (checkCoverage propSplitCoinPreservesSum)
         it "produces only valid coins"
@@ -782,6 +784,10 @@ propSplitCoinDataCoverage (SplitCoinData coinToSplit coinsToIncrease) =
         if count == 0
         then getCoin coinToSplit
         else getCoin coinToSplit `div` fromIntegral count
+
+propSplitCoinDataGenerationValid :: SplitCoinData -> Property
+propSplitCoinDataGenerationValid scd = property $
+    all isValidCoin (scdCoinToSplit scd : scdCoinsToIncrease scd)
 
 propSplitCoinPreservesSum :: SplitCoinData -> Property
 propSplitCoinPreservesSum (SplitCoinData coinToSplit coinsToIncrease) =

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -779,6 +779,8 @@ propSplitCoinDataCoverage (SplitCoinData coinToSplit coinsToIncrease) =
             "at least one coin within list is maximal"
         $ cover 8 (any notMaximalButWouldOverflowIfIncreased coinsToIncrease)
             "at least one coin is not maximal but would overflow if increased"
+        $ cover 8 (length coinsToIncrease > fromIntegral (getCoin coinToSplit))
+            "coin to split is smaller than number of coins to increase"
         True
   where
     count = length coinsToIncrease

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -37,7 +37,7 @@ import Cardano.Fee
     , splitCoin
     )
 import Cardano.Types
-    ( Coin (..), ShowFmt (..), UTxO (..) )
+    ( Coin (..), ShowFmt (..), UTxO (..), isValidCoin )
 import Control.Arrow
     ( left )
 import Control.Monad
@@ -395,6 +395,8 @@ spec = do
             (checkCoverage propSplitCoinDataCoverage)
         it "preserves the total sum"
             (checkCoverage propSplitCoinPreservesSum)
+        it "produces only valid coins"
+            (checkCoverage propSplitCoinProducesValidCoins)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Properties
@@ -787,6 +789,10 @@ propSplitCoinPreservesSum (SplitCoinData coinToSplit coinsToIncrease) =
   where
     totalAfter = sum (getCoin <$> splitCoin coinToSplit coinsToIncrease)
     totalBefore = getCoin coinToSplit + sum (getCoin <$> coinsToIncrease)
+
+propSplitCoinProducesValidCoins :: SplitCoinData -> Property
+propSplitCoinProducesValidCoins (SplitCoinData coinToSplit coinsToIncrease) =
+    property $ all isValidCoin $ splitCoin coinToSplit coinsToIncrease
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Unit Tests


### PR DESCRIPTION
## Related Issues

#18
#21
#22 

## Summary

This PR:

- [x] Clarifies the documentation of `splitCoin`, adding examples.
- [x] Tests that `splitCoin` preserves the total sum.
- [x] Tests that `splitCoin` only produces valid coins.