### PR TITLE
Clarify documentation and properties of `reduceChangeOutputs`.

### DIFF
--- a/src/Cardano/Fee.hs
+++ b/src/Cardano/Fee.hs
@@ -242,19 +242,11 @@ coverRemainingFee (Fee fee) = go [] where
                 Nothing -> do
                     lift $ throwE $ ErrCannotCoverFee (fee - sumInputs acc)
 
--- | Pay for the given fee by subtracting it from the given list of change
+-- | Pays for the given fee by subtracting it from the given list of change
 --   outputs, so that each change output is reduced by a portion of the fee
 --   that's in proportion to its relative size.
 --
--- Any dust outputs in the resulting list are coalesced according to the given
--- dust threshold. (See 'coalesceDust'.)
---
--- If there's not enough change to pay for the fee, or if there's only just
--- enough to cover it, this function returns the /empty list/.
---
--- == Examples
---
--- ==== Proportionality
+-- == Basic Examples
 --
 -- >>> reduceChangeOutputs (DustThreshold 0) (Fee 4) (Coin <$> [2, 2, 2, 2])
 -- [Coin 1, Coin 1, Coin 1, Coin 1]
@@ -262,10 +254,24 @@ coverRemainingFee (Fee fee) = go [] where
 -- >>> reduceChangeOutputs (DustThreshold 0) (Fee 15) (Coin <$> [2, 4, 8, 16])
 -- [Coin 1, Coin 2, Coin 4, Coin 8]
 --
--- ==== Dust Coalescing
+-- == Handling Dust
+--
+-- Any dust outputs in the resulting list are coalesced according to the given
+-- dust threshold: (See 'coalesceDust'.)
 --
 -- >>> reduceChangeOutputs (DustThreshold 1) (Fee 4) (Coin <$> [2, 2, 2, 2])
 -- [Coin 4]
+--
+-- == Handling Insufficient Change
+--
+-- If there's not enough change to pay for the fee, or if there's only just
+-- enough to pay for it exactly, this function returns the /empty list/:
+--
+-- >>> reduceChangeOutputs (DustThreshold 0) (Fee 15) (Coin <$> [10])
+-- []
+--
+-- >>> reduceChangeOutputs (DustThreshold 0) (Fee 15) (Coin <$> [1, 2, 4, 8])
+-- []
 --
 reduceChangeOutputs :: DustThreshold -> Fee -> [Coin] -> [Coin]
 reduceChangeOutputs threshold (Fee totalFee) changeOutputs

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -387,6 +387,10 @@ spec = do
     describe "reduceChangeOutputs" $ do
         it "data coverage is adequate"
             (checkCoverage propReduceChangeOutputsDataCoverage)
+        it "data generation is valid"
+            (checkCoverage propReduceChangeOutputsDataGenerationValid)
+        it "data shrinking is valid"
+            (checkCoverage propReduceChangeOutputsDataShrinkingValid)
         it "produces only valid coins"
             (checkCoverage propReduceChangeOutputsProducesValidCoins)
         it "preserves sum"
@@ -714,6 +718,18 @@ propReduceChangeOutputsDataCoverage
             $ cover 8 (fee > coinSum)
                 "fee > sum coins"
             True
+
+propReduceChangeOutputsDataGenerationValid
+    :: ReduceChangeOutputsData -> Property
+propReduceChangeOutputsDataGenerationValid rcod = property $
+    all isValidCoin (rcodCoins rcod)
+
+propReduceChangeOutputsDataShrinkingValid
+    :: ReduceChangeOutputsData -> Property
+propReduceChangeOutputsDataShrinkingValid rcod = property $
+    all isValidData (shrink rcod)
+  where
+    isValidData d = all isValidCoin (rcodCoins d)
 
 propReduceChangeOutputsProducesValidCoins :: ReduceChangeOutputsData -> Property
 propReduceChangeOutputsProducesValidCoins

--- a/test/Cardano/FeeSpec.hs
+++ b/test/Cardano/FeeSpec.hs
@@ -387,6 +387,8 @@ spec = do
     describe "reduceChangeOutputs" $ do
         it "data coverage is adequate"
             (checkCoverage propReduceChangeOutputsDataCoverage)
+        it "produces only valid coins"
+            (checkCoverage propReduceChangeOutputsProducesValidCoins)
         it "preserves sum"
             (checkCoverage propReduceChangeOutputsPreservesSum)
 
@@ -712,6 +714,11 @@ propReduceChangeOutputsDataCoverage
             $ cover 8 (fee > coinSum)
                 "fee > sum coins"
             True
+
+propReduceChangeOutputsProducesValidCoins :: ReduceChangeOutputsData -> Property
+propReduceChangeOutputsProducesValidCoins
+    (ReduceChangeOutputsData fee threshold coins) = property $
+        all isValidCoin (reduceChangeOutputs threshold fee coins)
 
 propReduceChangeOutputsPreservesSum :: ReduceChangeOutputsData -> Property
 propReduceChangeOutputsPreservesSum


### PR DESCRIPTION
## Related Issues

#18
#21
#22 

## Summary

This PR:

- [x] Clarifies the documentation of `reduceChangeOutputs`, adding examples.
- [x] Tests that `reduceChangeOutputs` only produces valid coins.