### PR TITLE
Make `remainingFee` more amenable to property testing.

### DIFF
--- a/src/library/Cardano/CoinSelection/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Migration.hs
@@ -48,7 +48,7 @@ import Cardano.CoinSelection
     , inputBalance
     )
 import Cardano.Fee
-    ( DustThreshold (..), Fee (..), FeeOptions (..) )
+    ( DustThreshold (..), Fee (..), FeeEstimator (..), FeeOptions (..) )
 import Cardano.Types
     ( Coin (..), UTxO (..) )
 import Control.Monad.Trans.State
@@ -142,7 +142,7 @@ depleteUTxO feeOpts batchSize utxo =
         diff = actualFee - integer requiredFee
           where
             (Fee requiredFee) =
-                estimateFee feeOpts coinSel
+                estimateFee (feeEstimator feeOpts) coinSel
             actualFee =
                 integer (inputBalance coinSel) - integer (changeBalance coinSel)
 

--- a/src/library/Cardano/Fee.hs
+++ b/src/library/Cardano/Fee.hs
@@ -420,25 +420,24 @@ remainingFee
     => FeeEstimator i o
     -> CoinSelection i o
     -> Fee
-remainingFee FeeEstimator {estimateFee} s = do
-    if fee >= diff
-    then Fee (fee - diff)
-    else do
+remainingFee FeeEstimator {estimateFee} s
+    | fee >= diff =
+        Fee (fee - diff)
+    | feeDangling >= diff =
+        Fee (feeDangling - fee)
+    | otherwise =
         -- NOTE
         -- The only case where we may end up with an unbalanced transaction is
         -- when we have a dangling change output (i.e. adding it costs too much
         -- and we can't afford it, but not having it result in too many coins
         -- left for fees).
-
-        if (feeDangling >= diff)
-            then Fee (feeDangling - fee)
-            else error $ unwords
-                [ "Generated an unbalanced tx! Too much left for fees"
-                , ": fee (raw) =", show fee
-                , ": fee (dangling) =", show feeDangling
-                , ", diff =", show diff
-                , "\nselection =", pretty s
-                ]
+        error $ unwords
+            [ "Generated an unbalanced tx! Too much left for fees"
+            , ": fee (raw) =", show fee
+            , ": fee (dangling) =", show feeDangling
+            , ", diff =", show diff
+            , "\nselection =", pretty s
+            ]
   where
     Fee fee = estimateFee s
     diff = feeBalance s

--- a/src/library/Cardano/Fee.hs
+++ b/src/library/Cardano/Fee.hs
@@ -199,11 +199,11 @@ senderPaysFee FeeOptions {feeEstimator, dustThreshold} utxo sel =
         -- 1/
         -- We compute fees using all inputs, outputs and changes since all of
         -- them have an influence on the fee calculation.
-        let upperBound = estimateFee feeEstimator coinSel
+        let feeUpperBound = estimateFee feeEstimator coinSel
         -- 2/
         -- Substract fee from change outputs, proportionally to their value.
-        let coinSel' = coinSel
-                { change = reduceChangeOutputs dustThreshold upperBound chgs }
+        let chgs' = reduceChangeOutputs dustThreshold feeUpperBound chgs
+        let coinSel' = coinSel { change = chgs' }
         let remFee = remainingFee feeEstimator coinSel'
         -- 3.1/
         -- Should the change cover the fee, we're (almost) good. By removing

--- a/src/library/Cardano/Fee.hs
+++ b/src/library/Cardano/Fee.hs
@@ -202,11 +202,8 @@ senderPaysFee FeeOptions {feeEstimator, dustThreshold} utxo sel =
         let upperBound = estimateFee feeEstimator coinSel
         -- 2/
         -- Substract fee from change outputs, proportionally to their value.
-        let coinSel' = CoinSelection
-                { inputs = inps
-                , outputs = outs
-                , change = reduceChangeOutputs dustThreshold upperBound chgs
-                }
+        let coinSel' = coinSel
+                { change = reduceChangeOutputs dustThreshold upperBound chgs }
         let remFee = remainingFee feeEstimator coinSel'
         -- 3.1/
         -- Should the change cover the fee, we're (almost) good. By removing

--- a/src/library/Cardano/Fee.hs
+++ b/src/library/Cardano/Fee.hs
@@ -421,9 +421,7 @@ coalesceDust (DustThreshold threshold) coins =
 
 -- | Computes how much is left to pay given a particular selection
 remainingFee
-    :: HasCallStack
-    => Buildable i
-    => Buildable o
+    :: (HasCallStack, Buildable i, Buildable o)
     => FeeEstimator i o
     -> CoinSelection i o
     -> Fee

--- a/src/library/Cardano/Fee.hs
+++ b/src/library/Cardano/Fee.hs
@@ -189,7 +189,7 @@ senderPaysFee
     -> UTxO u
     -> CoinSelection i o
     -> ExceptT ErrAdjustForFee m (CoinSelection i o)
-senderPaysFee options@(FeeOptions feeEstimator dustThreshold) utxo sel =
+senderPaysFee FeeOptions {feeEstimator, dustThreshold} utxo sel =
     evalStateT (go sel) utxo
   where
     go
@@ -207,7 +207,7 @@ senderPaysFee options@(FeeOptions feeEstimator dustThreshold) utxo sel =
                 , outputs = outs
                 , change = reduceChangeOutputs dustThreshold upperBound chgs
                 }
-        let remFee = remainingFee options coinSel'
+        let remFee = remainingFee feeEstimator coinSel'
         -- 3.1/
         -- Should the change cover the fee, we're (almost) good. By removing
         -- change outputs, we make them smaller and may reduce the size of the
@@ -427,10 +427,10 @@ remainingFee
     :: HasCallStack
     => Buildable i
     => Buildable o
-    => FeeOptions i o
+    => FeeEstimator i o
     -> CoinSelection i o
     -> Fee
-remainingFee (FeeOptions (FeeEstimator {estimateFee}) _) s = do
+remainingFee FeeEstimator {estimateFee} s = do
     if fee >= diff
     then Fee (fee - diff)
     else do

--- a/src/library/Cardano/Fee.hs
+++ b/src/library/Cardano/Fee.hs
@@ -47,12 +47,7 @@ import Prelude hiding
     ( round )
 
 import Cardano.CoinSelection
-    ( CoinSelection (..)
-    , Input (..)
-    , changeBalance
-    , inputBalance
-    , outputBalance
-    )
+    ( CoinSelection (..), Input (..), feeBalance )
 import Cardano.Types
     ( Coin (..), UTxO (..), coinIsValid, utxoPickRandom )
 import Control.Monad.Trans.Class
@@ -447,7 +442,7 @@ remainingFee FeeEstimator {estimateFee} s = do
                 ]
   where
     Fee fee = estimateFee s
-    diff = inputBalance s - (outputBalance s + changeBalance s)
+    diff = feeBalance s
 
 -- | Splits up the given coin of value __@v@__, distributing its value over the
 --   given coin list of length __@n@__, so that each coin value is increased by

--- a/src/library/Cardano/Fee.hs
+++ b/src/library/Cardano/Fee.hs
@@ -99,8 +99,8 @@ newtype Fee = Fee
 
 -- | Defines the maximum size of a dust coin.
 --
--- Change values that are less than or equal to this threshold will be
--- evicted from created transactions.
+-- Change values that are less than or equal to this threshold will not be
+-- included in transactions.
 --
 -- This type is isomorphic to 'Coin'.
 --

--- a/src/library/Cardano/Fee.hs
+++ b/src/library/Cardano/Fee.hs
@@ -429,8 +429,7 @@ remainingFee FeeEstimator {estimateFee} s = do
         -- when we have a dangling change output (i.e. adding it costs too much
         -- and we can't afford it, but not having it result in too many coins
         -- left for fees).
-        let Fee feeDangling =
-                estimateFee s { change = [Coin (diff - fee)] }
+
         if (feeDangling >= diff)
             then Fee (feeDangling - fee)
             else error $ unwords
@@ -443,6 +442,7 @@ remainingFee FeeEstimator {estimateFee} s = do
   where
     Fee fee = estimateFee s
     diff = feeBalance s
+    Fee feeDangling = estimateFee s { change = [Coin (diff - fee)] }
 
 -- | Splits up the given coin of value __@v@__, distributing its value over the
 --   given coin list of length __@n@__, so that each coin value is increased by

--- a/src/test/Cardano/FeeSpec.hs
+++ b/src/test/Cardano/FeeSpec.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -1042,18 +1043,19 @@ instance (Arbitrary i, Arbitrary o, Ord i, Ord o) =>
             >>= genOutputs
         genSelection (NE.fromList outs)
 
-instance Arbitrary (FeeOptions i o) where
+instance Arbitrary (FeeEstimator i o) where
     arbitrary = do
-        t <- choose (0, 10) -- dust threshold
         c <- choose (0, 10) -- price per transaction
         a <- choose (0, 10) -- price per input/output
-        return $ FeeOptions
-            { feeEstimator = FeeEstimator $
-                \s -> Fee
-                    $ fromIntegral
-                    $ c + a * (length (inputs s) + length (outputs s))
-            , dustThreshold = DustThreshold t
-            }
+        return $ FeeEstimator $ \s -> Fee
+            $ fromIntegral
+            $ c + a * (length (inputs s) + length (outputs s))
+
+instance Arbitrary (FeeOptions i o) where
+    arbitrary = do
+        dustThreshold <- DustThreshold <$> choose (0, 10)
+        feeEstimator <- arbitrary
+        return $ FeeOptions {dustThreshold, feeEstimator}
 
 instance Arbitrary a => Arbitrary (NonEmpty a) where
     arbitrary = do

--- a/src/test/Cardano/FeeSpec.hs
+++ b/src/test/Cardano/FeeSpec.hs
@@ -78,6 +78,7 @@ import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
     , Property
+    , arbitraryBoundedIntegral
     , checkCoverage
     , choose
     , cover
@@ -1007,7 +1008,7 @@ instance (i ~ u, Arbitrary o, Arbitrary u, Ord o, Ord u) =>
 instance Arbitrary (Hash "Tx") where
     shrink _ = []
     arbitrary = do
-        bytes <- BS.pack <$> vectorOf 32 arbitrary
+        bytes <- BS.pack <$> vectorOf 8 arbitraryBoundedIntegral
         pure $ Hash bytes
 
 instance Arbitrary Address where

--- a/src/test/Cardano/FeeSpec.hs
+++ b/src/test/Cardano/FeeSpec.hs
@@ -29,6 +29,7 @@ import Cardano.Fee
     ( DustThreshold (..)
     , ErrAdjustForFee (..)
     , Fee (..)
+    , FeeEstimator (..)
     , FeeOptions (..)
     , adjustForFee
     , coalesceDust
@@ -861,7 +862,7 @@ feeOptions
     -> Word64
     -> FeeOptions i o
 feeOptions fee dust = FeeOptions
-    { estimateFee =
+    { feeEstimator = FeeEstimator $
         \_ -> Fee fee
     , dustThreshold =
         DustThreshold dust
@@ -1047,7 +1048,7 @@ instance Arbitrary (FeeOptions i o) where
         c <- choose (0, 10) -- price per transaction
         a <- choose (0, 10) -- price per input/output
         return $ FeeOptions
-            { estimateFee =
+            { feeEstimator = FeeEstimator $
                 \s -> Fee
                     $ fromIntegral
                     $ c + a * (length (inputs s) + length (outputs s))


### PR DESCRIPTION
## Related Issues

#21 
#22 

## Summary

This PR:

- [x] Adds a new type `FeeEstimator`, which wraps the `estimateFee` function. Values of this type can be passed to functions that don't care about `DustThreshold` (instead of `FeeOptions`).
- [x] Adjusts the type of `remainingFee` to accept `FeeEstimator` rather than `FeeOptions`, making it easier to test. (We no longer need to provide a dust threshold, which will be ignored anyway.)
- [x] Adds the type `FeeParameters` for testing, with a function to create a `FeeEstimator` from a `FeeParameters`. Unlike `FeeEstimator`, `FeeParameters` can have a `Show` instance, which makes it much easier to debug failing properties.

- [x] Some related simplifications of the code.

A further PR will provide property tests for `remainingFee`.