### PR TITLE
Additional `CoinMap` Test Coverage

### DIFF
--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -100,6 +100,9 @@ spec = do
             checkCoverage $ prop_CoinMap_coverage @Int
         it "CoinMapEntry coverage is adequate" $
             checkCoverage $ prop_CoinMapEntry_coverage @Int
+        it "coinMapFromList preserves total value for each unique key" $
+            checkCoverage $
+                prop_coinMapFromList_preservesTotalValueForEachUniqueKey @Int
         it "coinMapFromList preserves total value" $
             checkCoverage $ prop_coinMapFromList_preservesTotalValue @Int
         it "coinMapToList preserves total value" $
@@ -177,6 +180,19 @@ prop_CoinMapEntry_coverage entries = property
         & Map.fromListWith (+)
         & Map.filter (> 1)
         & Map.keysSet
+
+prop_coinMapFromList_preservesTotalValueForEachUniqueKey
+    :: (Ord u, Show u)
+    => [CoinMapEntry u]
+    -> Property
+prop_coinMapFromList_preservesTotalValueForEachUniqueKey entries = property $
+    mkEntryMap entries
+        `shouldBe`
+        mkEntryMap (coinMapToList (coinMapFromList entries))
+  where
+    mkEntryMap
+        = Map.fromListWith (\c1 c2 -> Coin $ unCoin c1 + unCoin c2)
+        . fmap (entryKey &&& entryValue)
 
 prop_coinMapFromList_preservesTotalValue
     :: Ord u

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -101,9 +101,9 @@ spec = do
         it "CoinMapEntry coverage is adequate" $
             checkCoverage $ prop_CoinMapEntry_coverage @Int
         it "coinMapFromList preserves total value" $
-            checkCoverage $ prop_coinMapFromList_preservesValue @Int
+            checkCoverage $ prop_coinMapFromList_preservesTotalValue @Int
         it "coinMapToList preserves total value" $
-            checkCoverage $ prop_coinMapToList_preservesValue @Int
+            checkCoverage $ prop_coinMapToList_preservesTotalValue @Int
         it "coinMapFromList . coinMapToList = id" $
             checkCoverage $ prop_coinMapToList_coinMapFromList @Int
         it "coinMapToList order deterministic" $
@@ -114,7 +114,8 @@ spec = do
         it "monoidal append preserves keys" $
             checkCoverage $ prop_coinSelection_mappendPreservesKeys @Int @Int
         it "monoidal append preserves value" $
-            checkCoverage $ prop_coinSelection_mappendPreservesValue @Int @Int
+            checkCoverage $
+                prop_coinSelection_mappendPreservesTotalValue @Int @Int
 
   where
     lowerConfidence :: Confidence
@@ -177,18 +178,18 @@ prop_CoinMapEntry_coverage entries = property
         & Map.filter (> 1)
         & Map.keysSet
 
-prop_coinMapFromList_preservesValue
+prop_coinMapFromList_preservesTotalValue
     :: Ord u
     => [CoinMapEntry u]
     -> Property
-prop_coinMapFromList_preservesValue entries = property $
+prop_coinMapFromList_preservesTotalValue entries = property $
     mconcat (entryValue <$> entries)
         `shouldBe` coinMapValue (coinMapFromList entries)
 
-prop_coinMapToList_preservesValue
+prop_coinMapToList_preservesTotalValue
     :: CoinMap u
     -> Property
-prop_coinMapToList_preservesValue m = property $
+prop_coinMapToList_preservesTotalValue m = property $
     mconcat (entryValue <$> coinMapToList m)
         `shouldBe` coinMapValue m
 
@@ -226,12 +227,12 @@ prop_coinSelection_mappendPreservesKeys s1 s2 = property $ do
         `Set.union`
         Map.keysSet (unCoinMap $ outputs s2)
 
-prop_coinSelection_mappendPreservesValue
+prop_coinSelection_mappendPreservesTotalValue
     :: (Ord i, Ord o)
     => CoinSelection i o
     -> CoinSelection i o
     -> Property
-prop_coinSelection_mappendPreservesValue s1 s2 = property $ do
+prop_coinSelection_mappendPreservesTotalValue s1 s2 = property $ do
     sumInputs  s1 <> sumInputs  s2 `shouldBe` sumInputs  (s1 <> s2)
     sumOutputs s1 <> sumOutputs s2 `shouldBe` sumOutputs (s1 <> s2)
     sumChange  s1 <> sumChange  s2 `shouldBe` sumChange  (s1 <> s2)


### PR DESCRIPTION
## Related Issue

#30 

## Summary

This PR fills in some gaps in test coverage for `CoinMap`:

- [x] Tests that `[CoinMapEntry u]` value generation gives adequate coverage for all interesting cases.
- [x] Tests that `coinMapFromList` preserves the total value for each unique key.
- [x] Tests that `coinMapFromList . coinMapToList == id` (always).
- [x] Tests that `coinMapToList . coinMapFromList == id` (if and only if there are no duplicate keys).