### PR TITLE
Fix spelling error in `ErrUtxoFullyDepleted`.

### DIFF
--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -255,7 +255,7 @@ data CoinSelectionError e
     -- Records the /number/ of UTxO entries, as well as the /number/ of the
     -- transaction outputs.
     --
-    | ErrUxtoFullyDepleted
+    | ErrUtxoFullyDepleted
     -- ^ Due to the particular distribution of values within the UTxO set, all
     -- available UTxO entries were depleted before all the requested
     -- transaction outputs could be paid for.

--- a/src/library/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/library/Cardano/CoinSelection/LargestFirst.hs
@@ -165,7 +165,7 @@ import qualified Data.List as L
 --      set, the algorithm depletes all entries from the UTxO set /before/ it
 --      is able to pay for all requested outputs.
 --
---      See: __'ErrUxtoFullyDepleted'__.
+--      See: __'ErrUtxoFullyDepleted'__.
 --
 --  4.  The /number/ of UTxO entries needed to pay for the requested outputs
 --      would /exceed/ the upper limit specified by 'maximumInputCount'.
@@ -197,7 +197,7 @@ payForOutputs options utxo outputsRequested =
       | utxoCount < outputCount =
           ErrUtxoNotFragmentedEnough utxoCount outputCount
       | utxoCount <= inputCountMax =
-          ErrUxtoFullyDepleted
+          ErrUtxoFullyDepleted
       | otherwise =
           ErrMaximumInputCountExceeded inputCountMax
     amountAvailable =

--- a/src/library/Cardano/CoinSelection/RandomImprove.hs
+++ b/src/library/Cardano/CoinSelection/RandomImprove.hs
@@ -170,7 +170,7 @@ import qualified Data.List as L
 --      set, the algorithm depletes all entries from the UTxO set /before/ it
 --      is able to pay for all requested outputs.
 --
---      See: __'ErrUxtoFullyDepleted'__.
+--      See: __'ErrUtxoFullyDepleted'__.
 --
 --  4.  The /number/ of UTxO entries needed to pay for the requested outputs
 --      would /exceed/ the upper limit specified by 'maximumInputCount'.

--- a/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -151,7 +151,7 @@ spec = do
         coinSelectionUnitTest largestFirst
             "UTxO balance sufficient, fragmented enough, but single output \
             \depletes all UTxO entries"
-            (Left ErrUxtoFullyDepleted)
+            (Left ErrUtxoFullyDepleted)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation
@@ -162,7 +162,7 @@ spec = do
         coinSelectionUnitTest largestFirst
             "UTxO balance sufficient, fragmented enough, but single output \
             \depletes all UTxO entries"
-            (Left ErrUxtoFullyDepleted)
+            (Left ErrUtxoFullyDepleted)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation

--- a/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -159,7 +159,7 @@ spec = do
 
         coinSelectionUnitTest randomImprove
             "enough funds, proper fragmentation, inputs depleted"
-            (Left ErrUxtoFullyDepleted)
+            (Left ErrUtxoFullyDepleted)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation


### PR DESCRIPTION
## Related Issue

#30 

## Summary

Fixes spelling error in `ErrUtxoFullyDepleted`:

```patch
- ErrUxtoFullyDepleted
+ ErrUtxoFullyDepleted
```