### PR TITLE
Disable Automatic Algorithm Fallback

### DIFF
--- a/src/library/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/library/Cardano/CoinSelection/LargestFirst.hs
@@ -201,7 +201,7 @@ payForOutputs options utxo outputsRequested =
       | otherwise =
           ErrMaximumInputCountExceeded inputCountMax
     amountAvailable =
-        fromIntegral $ unCoin $ coinMapValue utxo
+        unCoin $ coinMapValue utxo
     amountRequested =
         unCoin $ coinMapValue outputsRequested
     inputCountMax =


### PR DESCRIPTION
## Related Issue

#30 

## Summary

The `cardano-wallet` library currently performs **automatic fallback** from `Random-Improve` to `Largest-First` if the former algorithm is unable to compute a valid coin selection.

However, this automatic fallback might not be appropriate for all users of the coin selection library.

This PR:

- [x] **removes** the automatic fallback logic within the implementation of `Random-Improve`.
- [x] **adds** an appropriate error handling function, since `Random-Improve` can no longer rely on the error handling provided by `Largest-First`.

The error handling is already tested by our existing test suite.