### PR TITLE
Remove `Buildable` Instances from Public API.

### DIFF
--- a/cardano-coin-selection.cabal
+++ b/cardano-coin-selection.cabal
@@ -66,7 +66,6 @@ library
     , containers
     , cryptonite
     , deepseq
-    , fmt
     , quiet
     , text
     , transformers

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -54,8 +54,6 @@ import Data.Map.Strict
     ( Map )
 import Data.Word
     ( Word64, Word8 )
-import Fmt
-    ( Buildable (..), blockListF, listF, nameF )
 import GHC.Generics
     ( Generic )
 import Quiet
@@ -92,9 +90,6 @@ instance Bounded Coin where
         Coin 45_000_000_000_000_000
         -- = 45 billion Ada × 1 million Lovelace/Ada:
 
-instance Buildable Coin where
-    build = build . unCoin
-
 coinIsValid :: Coin -> Bool
 coinIsValid c = c >= minBound && c <= maxBound
 
@@ -121,12 +116,6 @@ data CoinMapEntry a = CoinMapEntry
     , entryValue
         :: Coin
     } deriving (Eq, Generic, Ord, Show)
-
-instance Buildable a => Buildable (CoinMapEntry a) where
-    build a = mempty
-        <> build (entryKey a)
-        <> ":"
-        <> build (entryValue a)
 
 coinMapFromList :: Ord a => [CoinMapEntry a] -> CoinMap a
 coinMapFromList = CoinMap
@@ -203,15 +192,6 @@ instance (Ord i, Ord o) => Semigroup (CoinSelection i o) where
 
 instance (Ord i, Ord o) => Monoid (CoinSelection i o) where
     mempty = CoinSelection mempty mempty mempty
-
-instance (Buildable i, Buildable o) => Buildable (CoinSelection i o) where
-    build s = mempty
-        <> nameF "inputs"
-            (blockListF $ coinMapToList $ inputs s)
-        <> nameF "outputs"
-            (blockListF $ coinMapToList $ outputs s)
-        <> nameF "change"
-            (listF $ change s)
 
 -- | Calculate the total sum of all 'inputs' for the given 'CoinSelection'.
 sumInputs :: CoinSelection i o -> Coin

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -77,8 +77,6 @@ import Data.Ratio
     ( (%) )
 import Data.Word
     ( Word64 )
-import Fmt
-    ( Buildable (..), pretty )
 import GHC.Generics
     ( Generic )
 import GHC.Stack
@@ -184,7 +182,7 @@ newtype ErrAdjustForFee
 -- outputs the algorithm happened to choose).
 --
 adjustForFee
-    :: (Buildable i, Buildable o, Ord i, MonadRandom m)
+    :: (Ord i, Show i, Show o, MonadRandom m)
     => FeeOptions i o
     -> CoinMap i
     -> CoinSelection i o
@@ -199,7 +197,7 @@ adjustForFee unsafeOpt utxo coinSel = do
 -- | The sender pays fee in this scenario, so fees are removed from the change
 -- outputs, and new inputs are selected if necessary.
 senderPaysFee
-    :: forall i o m . (Buildable i, Buildable o, Ord i, MonadRandom m)
+    :: forall i o m . (Ord i, Show i, Show o, MonadRandom m)
     => FeeOptions i o
     -> CoinMap i
     -> CoinSelection i o
@@ -436,7 +434,7 @@ coalesceDust (DustThreshold threshold) coins =
 
 -- | Computes how much is left to pay given a particular selection
 remainingFee
-    :: (HasCallStack, Buildable i, Buildable o)
+    :: (HasCallStack, Show i, Show o)
     => FeeEstimator i o
     -> CoinSelection i o
     -> Fee
@@ -456,7 +454,7 @@ remainingFee FeeEstimator {estimateFee} s
             , ": fee (raw) =", show fee
             , ": fee (dangling) =", show feeDangling
             , ", diff =", show diff
-            , "\nselection =", pretty s
+            , "\nselection =", show s
             ]
   where
     Fee fee = estimateFee s

--- a/src/test/Cardano/CoinSelection/FeeSpec.hs
+++ b/src/test/Cardano/CoinSelection/FeeSpec.hs
@@ -448,14 +448,7 @@ instance (Buildable i, Buildable o) =>
             <> nameF "options" (tupleF opt)
 
 propDeterministic
-    :: forall i o .
-        ( Buildable i
-        , Buildable o
-        , Ord i
-        , Ord o
-        , Show i
-        , Show o
-        )
+    :: forall i o . (Ord i, Ord o, Show i, Show o)
     => ShowFmt (FeeProp i o)
     -> Property
 propDeterministic (ShowFmt (FeeProp coinSel _ (fee, dust))) =
@@ -467,7 +460,7 @@ propDeterministic (ShowFmt (FeeProp coinSel _ (fee, dust))) =
         resultOne `shouldBe` resultTwo
 
 propReducedChanges
-    :: forall i o . (Buildable i, Buildable o, Ord i)
+    :: forall i o . (Show i, Show o, Ord i)
     => SystemDRG
     -> ShowFmt (FeeProp i o)
     -> Property

--- a/src/test/Cardano/Test/Utilities.hs
+++ b/src/test/Cardano/Test/Utilities.hs
@@ -8,8 +8,9 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- | Utility functions and types used purely for testing.
+-- | Utility functions, types, and type class instances used purely for testing.
 --
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -43,7 +44,12 @@ module Cardano.Test.Utilities
 import Prelude
 
 import Cardano.CoinSelection
-    ( Coin (..), CoinMap (..) )
+    ( Coin (..)
+    , CoinMap (..)
+    , CoinMapEntry (..)
+    , CoinSelection (..)
+    , coinMapToList
+    )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.ByteArray
@@ -57,7 +63,15 @@ import Data.Set
 import Data.Word
     ( Word32 )
 import Fmt
-    ( Buildable (..), fmt, ordinalF, prefixF, suffixF )
+    ( Buildable (..)
+    , blockListF
+    , fmt
+    , listF
+    , nameF
+    , ordinalF
+    , prefixF
+    , suffixF
+    )
 import GHC.Generics
     ( Generic )
 import GHC.Stack
@@ -195,3 +209,25 @@ restrictedBy (CoinMap utxo) =
 restrictedTo :: CoinMap u -> Set Coin -> CoinMap u
 restrictedTo (CoinMap utxo) outs =
     CoinMap $ Map.filter (`Set.member` outs) utxo
+
+--------------------------------------------------------------------------------
+-- Buildable Instances
+--------------------------------------------------------------------------------
+
+instance Buildable Coin where
+    build = build . unCoin
+
+instance Buildable a => Buildable (CoinMapEntry a) where
+    build a = mempty
+        <> build (entryKey a)
+        <> ":"
+        <> build (entryValue a)
+
+instance (Buildable i, Buildable o) => Buildable (CoinSelection i o) where
+    build s = mempty
+        <> nameF "inputs"
+            (blockListF $ coinMapToList $ inputs s)
+        <> nameF "outputs"
+            (blockListF $ coinMapToList $ outputs s)
+        <> nameF "change"
+            (listF $ change s)


### PR DESCRIPTION
## Related Issue

#30 

## Summary

This PR:

- [x] Removes all `Buildable` instances from the public API.
- [x] Relocates those instances still required by the test suite to the `Test.Utilities` module.
- [x] Removes the dependency on `fmt` from the public library.