### PR TITLE
Add Haddock documentation to `CoinSelection` module.

### DIFF
--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -209,13 +209,13 @@ newtype CoinSelectionAlgorithm i o m e = CoinSelectionAlgorithm
         -> ExceptT (CoinSelectionError e) m (CoinSelection i o, CoinMap i)
     }
 
--- | Represents the result of running a /coin selection algorithm/.
+-- | Represents the /result/ of running a coin selection algorithm.
 --
 -- See 'CoinSelectionAlgorithm'.
 --
 data CoinSelection i o = CoinSelection
     { inputs :: CoinMap i
-      -- ^ A /subset/ of the original 'UTxO' that was passed to the coin
+      -- ^ A /subset/ of the original UTxO set that was passed to the coin
       -- selection algorithm, containing only the entries that were /selected/
       -- by the coin selection algorithm.
     , outputs :: CoinMap o

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -181,12 +181,25 @@ coinMapRandomEntry (CoinMap m)
 -- Coin Selection
 --------------------------------------------------------------------------------
 
--- | Represents a /coin selection algorithm/.
+-- | Provides a common interface for coin selection algorithms.
 --
--- The function 'selectCoins', when applied to the given /output list/ and
--- /initial UTxO set/, generates a 'CoinSelection' that is capable of paying
+-- The function 'selectCoins', when applied to the given /initial UTxO set/
+-- and /output set/, generates a 'CoinSelection' that is capable of paying
 -- for all of the outputs, and a /remaining UTxO set/ from which all spent
 -- values have been removed.
+--
+-- Each entry in the /initial UTxO set/ refers to a unique unspent output from
+-- a previous transaction, together with its corresponding value. The algorithm
+-- will select from among the entries in this set to pay for entries in the
+-- output set, placing the selected entries in the 'inputs' field of the
+-- resulting 'CoinSelection'.
+--
+-- Each entry in the /output set/ refers to a unique payment recipient together
+-- with the value to pay to that recipient. The 'outputs' field of the
+-- resulting 'CoinSelection' will be equal to this set.
+--
+-- The total value of the initial UTxO set must be /greater than or equal to/
+-- the total value of the output set, as given by the 'coinMapValue' function.
 --
 newtype CoinSelectionAlgorithm i o m e = CoinSelectionAlgorithm
     { selectCoins

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -8,8 +8,13 @@
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
 --
--- Provides general functions and types relating to coin selection and fee
--- balancing.
+-- Provides general functions and types relating to coin selection.
+--
+-- The 'CoinSelectionAlgorithm' type provides a /common interface/ to coin
+-- selection algorithms.
+--
+-- The 'CoinSelection' type represents the /result/ of running a coin selection
+-- algorithm.
 --
 module Cardano.CoinSelection
     (

--- a/src/library/Cardano/CoinSelection/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Migration.hs
@@ -42,11 +42,12 @@ import Prelude
 
 import Cardano.CoinSelection
     ( Coin (..)
-    , CoinMap (..)
+    , CoinMap
     , CoinMapEntry (..)
     , CoinSelection (..)
     , CoinSelectionOptions (..)
     , coinMapFromList
+    , coinMapToList
     , sumChange
     , sumInputs
     )
@@ -60,8 +61,6 @@ import Data.Maybe
     ( mapMaybe )
 import Data.Word
     ( Word8 )
-
-import qualified Data.Map.Strict as Map
 
 -- | Construct a list of coin selections / transactions to transfer the totality
 -- of a user's wallet. The resulting 'CoinSelection' do not contain any
@@ -83,7 +82,7 @@ depleteUTxO
         -- ^ UTxO to deplete
     -> [CoinSelection i o]
 depleteUTxO feeOpts batchSize utxo =
-    evalState migrate (uncurry CoinMapEntry <$> Map.toList (unCoinMap utxo))
+    evalState migrate (coinMapToList utxo)
   where
     migrate :: State [CoinMapEntry i] [CoinSelection i o]
     migrate = do


### PR DESCRIPTION
## Related Issue

#18 

## Summary

This PR adds (and revises in some places) Haddock documentation for the `Cardano.CoinSelection` module:

- [x] Adds a simple module overview.
- [x] Extends the documentation for `CoinSelection`.
- [x] Extends the documentation for `CoinSelectionAlgorithm`.
- [x] Adds documentation for `CoinMap` (and related functions) linking it together with `CoinSelectionAlgorithm`.