### PR TITLE
Public API of `CoinSelection` Module.

### DIFF
--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -297,7 +297,7 @@ data CoinSelectionError
     -- available UTxO entries were depleted before all the requested
     -- transaction outputs could be paid for.
     --
-    | ErrMaximumInputCountExceeded Natural
+    | ErrLimitExceeded Natural
     -- ^ The number of UTxO entries needed to cover the requested payment
     -- exceeded the upper limit specified by 'limit'.
     --

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -12,7 +12,7 @@
 -- Provides general functions and types relating to coin selection.
 --
 -- The 'CoinSelection' type represents a __coin selection__, the basis for a
--- /transaction/.
+-- /transaction/ in a UTxO-based blockchain.
 --
 -- The 'CoinSelectionAlgorithm' type provides a __common interface__ to
 -- algorithms that generate coin selections.

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -39,6 +39,7 @@ module Cardano.CoinSelection
 
       -- * Coin Selection Algorithms
     , CoinSelectionAlgorithm (..)
+    , CoinSelectionParameters (..)
     , CoinSelectionInputLimit (..)
     , CoinSelectionError (..)
 
@@ -165,11 +166,21 @@ coinMapValue = mconcat . fmap entryValue . coinMapToList
 --
 newtype CoinSelectionAlgorithm i o m = CoinSelectionAlgorithm
     { selectCoins
-        :: CoinSelectionInputLimit
-        -> CoinMap i
-        -> CoinMap o
+        :: CoinSelectionParameters i o
         -> ExceptT CoinSelectionError m (CoinSelection i o, CoinMap i)
     }
+
+-- | The complete set of parameters required for a 'CoinSelectionAlgorithm'.
+--
+data CoinSelectionParameters i o = CoinSelectionParameters
+    { inputLimit :: CoinSelectionInputLimit
+        -- ^ A limit on the number of inputs that can be selected.
+    , inputsAvailable :: CoinMap i
+        -- ^ The set of inputs available for selection.
+    , outputsRequested :: CoinMap o
+        -- ^ The set of outputs requested for payment.
+    }
+    deriving Generic
 
 -- | Represents the __result__ of running a coin selection algorithm.
 --

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_HADDOCK prune #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -29,7 +30,6 @@ module Cardano.CoinSelection
     , coinMapFromList
     , coinMapToList
     , coinMapValue
-    , coinMapRandomEntry
 
       -- * Coin Selection
     , CoinSelection (..)
@@ -41,6 +41,9 @@ module Cardano.CoinSelection
     , CoinSelectionAlgorithm (..)
     , CoinSelectionOptions (..)
     , CoinSelectionError (..)
+
+      -- # Internal Functions
+    , coinMapRandomEntry
 
     ) where
 
@@ -135,24 +138,6 @@ coinMapToList = fmap (uncurry CoinMapEntry) . Map.toList . unCoinMap
 --
 coinMapValue :: CoinMap a -> Coin
 coinMapValue = mconcat . fmap entryValue . coinMapToList
-
--- | Selects an entry at random from a 'CoinMap', returning both the selected
---   entry and the map with the entry removed.
---
--- If the given map is empty, this function returns 'Nothing'.
---
-coinMapRandomEntry
-    :: MonadRandom m
-    => CoinMap a
-    -> m (Maybe (CoinMapEntry a), CoinMap a)
-coinMapRandomEntry (CoinMap m)
-    | Map.null m =
-        return (Nothing, CoinMap m)
-    | otherwise = do
-        ix <- fromEnum <$> generateBetween 0 (toEnum (Map.size m - 1))
-        let entry = uncurry CoinMapEntry $ Map.elemAt ix m
-        let remainder = CoinMap $ Map.deleteAt ix m
-        return (Just entry, remainder)
 
 --------------------------------------------------------------------------------
 -- Coin Selection
@@ -274,3 +259,25 @@ data CoinSelectionError e
     -- validate the selection.
     --
     deriving (Show, Eq)
+
+--------------------------------------------------------------------------------
+-- Internal Functions
+--------------------------------------------------------------------------------
+
+-- Selects an entry at random from a 'CoinMap', returning both the selected
+-- entry and the map with the entry removed.
+--
+-- If the given map is empty, this function returns 'Nothing'.
+--
+coinMapRandomEntry
+    :: MonadRandom m
+    => CoinMap a
+    -> m (Maybe (CoinMapEntry a), CoinMap a)
+coinMapRandomEntry (CoinMap m)
+    | Map.null m =
+        return (Nothing, CoinMap m)
+    | otherwise = do
+        ix <- fromEnum <$> generateBetween 0 (toEnum (Map.size m - 1))
+        let entry = uncurry CoinMapEntry $ Map.elemAt ix m
+        let remainder = CoinMap $ Map.deleteAt ix m
+        return (Just entry, remainder)

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -41,7 +41,7 @@ module Cardano.CoinSelection
     , CoinSelectionAlgorithm (..)
     , CoinSelectionParameters (..)
     , CoinSelectionResult (..)
-    , CoinSelectionInputLimit (..)
+    , CoinSelectionLimit (..)
     , CoinSelectionError (..)
 
       -- # Internal Functions
@@ -174,7 +174,7 @@ newtype CoinSelectionAlgorithm i o m = CoinSelectionAlgorithm
 -- | The complete set of parameters required for a 'CoinSelectionAlgorithm'.
 --
 data CoinSelectionParameters i o = CoinSelectionParameters
-    { inputLimit :: CoinSelectionInputLimit
+    { inputLimit :: CoinSelectionLimit
         -- ^ A limit on the number of inputs that can be selected.
     , inputsAvailable :: CoinMap i
         -- ^ The set of inputs available for selection.
@@ -237,7 +237,7 @@ sumChange = mconcat . change
 -- | Defines an inclusive upper bound on the number of inputs that
 --   a 'CoinSelectionAlgorithm' is allowed to select.
 --
-newtype CoinSelectionInputLimit = CoinSelectionInputLimit
+newtype CoinSelectionLimit = CoinSelectionLimit
     { calculateInputLimit
         :: Word8 -> Word8
             -- ^ Calculate the maximum number of inputs allowed for a given

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -40,6 +40,7 @@ module Cardano.CoinSelection
       -- * Coin Selection Algorithms
     , CoinSelectionAlgorithm (..)
     , CoinSelectionParameters (..)
+    , CoinSelectionResult (..)
     , CoinSelectionInputLimit (..)
     , CoinSelectionError (..)
 
@@ -167,7 +168,7 @@ coinMapValue = mconcat . fmap entryValue . coinMapToList
 newtype CoinSelectionAlgorithm i o m = CoinSelectionAlgorithm
     { selectCoins
         :: CoinSelectionParameters i o
-        -> ExceptT CoinSelectionError m (CoinSelection i o, CoinMap i)
+        -> ExceptT CoinSelectionError m (CoinSelectionResult i o)
     }
 
 -- | The complete set of parameters required for a 'CoinSelectionAlgorithm'.
@@ -185,6 +186,17 @@ data CoinSelectionParameters i o = CoinSelectionParameters
 -- | Represents the __result__ of running a coin selection algorithm.
 --
 -- See 'CoinSelectionAlgorithm'.
+--
+data CoinSelectionResult i o = CoinSelectionResult
+    { coinSelection :: CoinSelection i o
+        -- ^ The coin selection.
+    , inputsRemaining :: CoinMap i
+        -- ^ The set of inputs that were not selected.
+    }
+
+-- | Represents a selection of inputs, outputs, and change.
+--
+-- A coin selection is the basis for a transaction.
 --
 data CoinSelection i o = CoinSelection
     { inputs :: CoinMap i

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -268,9 +268,9 @@ data CoinSelectionError
     --
     | ErrMaximumInputCountExceeded Natural
     -- ^ The number of UTxO entries needed to cover the requested payment
-    -- exceeded the upper limit specified by 'calculateInputLimit'.
+    -- exceeded the upper limit specified by 'inputLimit'.
     --
-    -- Records the value of 'calculateInputLimit'.
+    -- Records the value of 'inputLimit'.
     --
     deriving (Show, Eq)
 

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -39,7 +39,7 @@ module Cardano.CoinSelection
 
       -- * Coin Selection Algorithms
     , CoinSelectionAlgorithm (..)
-    , CoinSelectionOptions (..)
+    , CoinSelectionInputLimit (..)
     , CoinSelectionError (..)
 
       -- # Internal Functions
@@ -165,7 +165,7 @@ coinMapValue = mconcat . fmap entryValue . coinMapToList
 --
 newtype CoinSelectionAlgorithm i o m = CoinSelectionAlgorithm
     { selectCoins
-        :: CoinSelectionOptions
+        :: CoinSelectionInputLimit
         -> CoinMap i
         -> CoinMap o
         -> ExceptT CoinSelectionError m (CoinSelection i o, CoinMap i)
@@ -211,10 +211,11 @@ sumOutputs =  coinMapValue . outputs
 sumChange :: CoinSelection i o -> Coin
 sumChange = mconcat . change
 
--- | Represents a set of options to be passed to a coin selection algorithm.
+-- | Defines an inclusive upper bound on the number of inputs that
+--   a 'CoinSelectionAlgorithm' is allowed to select.
 --
-newtype CoinSelectionOptions = CoinSelectionOptions
-    { maximumInputCount
+newtype CoinSelectionInputLimit = CoinSelectionInputLimit
+    { calculateInputLimit
         :: Word8 -> Word8
             -- ^ Calculate the maximum number of inputs allowed for a given
             -- number of outputs.
@@ -244,9 +245,9 @@ data CoinSelectionError
     --
     | ErrMaximumInputCountExceeded Natural
     -- ^ The number of UTxO entries needed to cover the requested payment
-    -- exceeded the upper limit specified by 'maximumInputCount'.
+    -- exceeded the upper limit specified by 'calculateInputLimit'.
     --
-    -- Records the value of 'maximumInputCount'.
+    -- Records the value of 'calculateInputLimit'.
     --
     deriving (Show, Eq)
 

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -163,12 +163,12 @@ coinMapValue = mconcat . fmap entryValue . coinMapToList
 -- The total value of the initial UTxO set must be /greater than or equal to/
 -- the total value of the output set, as given by the 'coinMapValue' function.
 --
-newtype CoinSelectionAlgorithm i o m e = CoinSelectionAlgorithm
+newtype CoinSelectionAlgorithm i o m = CoinSelectionAlgorithm
     { selectCoins
-        :: CoinSelectionOptions i o e
+        :: CoinSelectionOptions
         -> CoinMap i
         -> CoinMap o
-        -> ExceptT (CoinSelectionError e) m (CoinSelection i o, CoinMap i)
+        -> ExceptT CoinSelectionError m (CoinSelection i o, CoinMap i)
     }
 
 -- | Represents the __result__ of running a coin selection algorithm.
@@ -213,21 +213,17 @@ sumChange = mconcat . change
 
 -- | Represents a set of options to be passed to a coin selection algorithm.
 --
-data CoinSelectionOptions i o e = CoinSelectionOptions
+newtype CoinSelectionOptions = CoinSelectionOptions
     { maximumInputCount
         :: Word8 -> Word8
             -- ^ Calculate the maximum number of inputs allowed for a given
             -- number of outputs.
-    , validate
-        :: CoinSelection i o -> Either e ()
-            -- ^ Validate the given coin selection, returning a backend-specific
-            -- error.
-    } deriving (Generic)
+    } deriving Generic
 
 -- | Represents the set of possible failures that can occur when attempting
 --   to produce a 'CoinSelection'.
 --
-data CoinSelectionError e
+data CoinSelectionError
     = ErrUtxoBalanceInsufficient Coin Coin
     -- ^ The UTxO balance was insufficient to cover the total payment amount.
     --
@@ -251,12 +247,6 @@ data CoinSelectionError e
     -- exceeded the upper limit specified by 'maximumInputCount'.
     --
     -- Records the value of 'maximumInputCount'.
-    --
-    | ErrInvalidSelection e
-    -- ^ The coin selection generated was reported to be invalid by the backend.
-    --
-    -- Records the /backend-specific error/ that occurred while attempting to
-    -- validate the selection.
     --
     deriving (Show, Eq)
 

--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -11,33 +11,33 @@
 --
 -- Provides general functions and types relating to coin selection.
 --
--- The 'CoinSelectionAlgorithm' type provides a /common interface/ to coin
+-- The 'CoinSelectionAlgorithm' type provides a __common interface__ to coin
 -- selection algorithms.
 --
--- The 'CoinSelection' type represents the /result/ of running a coin selection
--- algorithm.
+-- The 'CoinSelection' type represents the __result__ of running a coin
+-- selection algorithm.
 --
 module Cardano.CoinSelection
     (
-      -- * Coin
+      -- * Coins
       Coin
     , coinFromNatural
     , coinToNatural
 
-      -- * Coin Map
+      -- * Coin Maps
     , CoinMap (..)
     , CoinMapEntry (..)
     , coinMapFromList
     , coinMapToList
     , coinMapValue
 
-      -- * Coin Selection
+      -- * Coin Selections
     , CoinSelection (..)
     , sumInputs
     , sumOutputs
     , sumChange
 
-      -- * Coin Selection Algorithm
+      -- * Coin Selection Algorithms
     , CoinSelectionAlgorithm (..)
     , CoinSelectionOptions (..)
     , CoinSelectionError (..)
@@ -143,7 +143,7 @@ coinMapValue = mconcat . fmap entryValue . coinMapToList
 -- Coin Selection
 --------------------------------------------------------------------------------
 
--- | Provides a common interface for coin selection algorithms.
+-- | Provides a __common interface__ for coin selection algorithms.
 --
 -- The function 'selectCoins', when applied to the given /initial UTxO set/
 -- and /output set/, generates a 'CoinSelection' that is capable of paying
@@ -171,15 +171,15 @@ newtype CoinSelectionAlgorithm i o m e = CoinSelectionAlgorithm
         -> ExceptT (CoinSelectionError e) m (CoinSelection i o, CoinMap i)
     }
 
--- | Represents the /result/ of running a coin selection algorithm.
+-- | Represents the __result__ of running a coin selection algorithm.
 --
 -- See 'CoinSelectionAlgorithm'.
 --
 data CoinSelection i o = CoinSelection
     { inputs :: CoinMap i
-      -- ^ A /subset/ of the original UTxO set that was passed to the coin
-      -- selection algorithm, containing only the entries that were /selected/
-      -- by the coin selection algorithm.
+      -- ^ A __subset__ of the original UTxO set that was passed to the coin
+      -- selection algorithm, containing __only__ the entries that were
+      -- selected by the coin selection algorithm.
     , outputs :: CoinMap o
       -- ^ The original set of output payments passed to the coin selection
       -- algorithm, whose total value is covered by the 'inputs'.

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -180,7 +180,7 @@ adjustForFee unsafeOpt utxo coinSel = do
 
 -- Calculates the current fee associated with a given 'CoinSelection'.
 --
--- If the result would be less than zero, returns 'Nothing'.
+-- If the result is less than zero, returns 'Nothing'.
 --
 calculateFee :: CoinSelection i o -> Maybe Fee
 calculateFee s = Fee <$> sumInputs s `C.sub` (sumOutputs s `C.add` sumChange s)

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -9,36 +9,32 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_HADDOCK prune #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
 --
--- Provides the API of Coin Selection algorithm and Fee Calculation
--- This module contains the implementation of adjusting coin selection for a
--- fee.  The sender pays for the fee and additional inputs are picked randomly.
--- For more information refer to:
--- https://iohk.io/blog/self-organisation-in-coin-selection/
-
+-- Provides functionality for __adjusting__ coin selections in order to pay for
+-- transaction __fees__.
+--
 module Cardano.CoinSelection.Fee
     (
-      -- * Fee Calculation
+      -- * Fundamental Types
       Fee (..)
-    , calculateFee
-    , distributeFee
+    , FeeEstimator (..)
+    , DustThreshold (..)
 
       -- * Fee Adjustment
-    , FeeEstimator (..)
-    , FeeOptions (..)
-    , ErrAdjustForFee(..)
     , adjustForFee
-    , reduceChangeOutputs
+    , FeeOptions (..)
+    , ErrAdjustForFee (..)
 
-      -- * Dust Processing
-    , DustThreshold (..)
+      -- # Internal Functions
+    , calculateFee
     , coalesceDust
-
-      -- * Coin Splitting
+    , distributeFee
+    , reduceChangeOutputs
     , splitCoin
 
     ) where
@@ -92,7 +88,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Internal.Coin as C
 
 --------------------------------------------------------------------------------
--- Types
+-- Fundamental Types
 --------------------------------------------------------------------------------
 
 -- | Represents a non-negative fee to be paid on a transaction.
@@ -111,21 +107,6 @@ newtype DustThreshold = DustThreshold { unDustThreshold :: Coin }
     deriving stock (Eq, Generic, Ord)
     deriving Show via (Quiet DustThreshold)
 
---------------------------------------------------------------------------------
--- Fee Calculation
---------------------------------------------------------------------------------
-
--- | Calculates the current fee associated with a given 'CoinSelection'.
---
--- If the result would be less than zero, returns 'Nothing'.
---
-calculateFee :: CoinSelection i o -> Maybe Fee
-calculateFee s = Fee <$> sumInputs s `C.sub` (sumOutputs s `C.add` sumChange s)
-
---------------------------------------------------------------------------------
--- Fee Adjustment
---------------------------------------------------------------------------------
-
 -- | Provides a function capable of estimating the fee for a given coin
 --   selection.
 --
@@ -136,7 +117,11 @@ newtype FeeEstimator i o = FeeEstimator
     { estimateFee :: CoinSelection i o -> Fee
     } deriving Generic
 
--- | Provides options for fee balancing.
+--------------------------------------------------------------------------------
+-- Fee Adjustment
+--------------------------------------------------------------------------------
+
+-- | Provides options for fee adjustment.
 --
 data FeeOptions i o = FeeOptions
     { feeEstimator
@@ -189,8 +174,20 @@ adjustForFee unsafeOpt utxo coinSel = do
   where
     nullFee opt = estimateFee (feeEstimator opt) coinSel == Fee C.zero
 
--- | The sender pays fee in this scenario, so fees are removed from the change
+--------------------------------------------------------------------------------
+-- Internal Functions
+--------------------------------------------------------------------------------
+
+-- Calculates the current fee associated with a given 'CoinSelection'.
+--
+-- If the result would be less than zero, returns 'Nothing'.
+--
+calculateFee :: CoinSelection i o -> Maybe Fee
+calculateFee s = Fee <$> sumInputs s `C.sub` (sumOutputs s `C.add` sumChange s)
+
+-- The sender pays fee in this scenario, so fees are removed from the change
 -- outputs, and new inputs are selected if necessary.
+--
 senderPaysFee
     :: forall i o m . (Ord i, Show i, Show o, MonadRandom m)
     => FeeOptions i o
@@ -238,8 +235,9 @@ senderPaysFee FeeOptions {feeEstimator, dustThreshold} utxo sel =
             let extraChange = splitCoin (sumEntries inps') chgs
             go $ CoinSelection (inps <> coinMapFromList inps') outs extraChange
 
--- | A short / simple version of the 'random' fee policy to cover for fee in
--- case where existing change were not enough.
+-- A short and simple version of the 'random' fee policy to cover for the fee
+-- in the case where existing set of change is not enough.
+--
 coverRemainingFee
     :: MonadRandom m
     => Fee
@@ -257,9 +255,9 @@ coverRemainingFee (Fee fee) = go [] where
                     lift $ throwE $ ErrCannotCoverFee $ Fee $
                         fee `C.distance` (sumEntries acc)
 
--- | Pays for the given fee by subtracting it from the given list of change
---   outputs, so that each change output is reduced by a portion of the fee
---   that's in proportion to its relative size.
+-- Pays for the given fee by subtracting it from the given list of change
+-- outputs, so that each change output is reduced by a portion of the fee
+-- that's in proportion to its relative size.
 --
 -- == Basic Examples
 --
@@ -309,8 +307,8 @@ reduceChangeOutputs threshold (Fee totalFee) changeOutputs
 
     totalChange = F.fold changeOutputs
 
--- | Distribute the given fee over the given list of coins, so that each coin
---   is allocated a __fraction__ of the fee in proportion to its relative size.
+-- Distribute the given fee over the given list of coins, so that each coin
+-- is allocated a __fraction__ of the fee in proportion to its relative size.
 --
 -- == Pre-condition
 --
@@ -414,9 +412,9 @@ distributeFee (Fee feeTotal) coinsUnsafe =
     totalCoinValue :: Coin
     totalCoinValue = F.fold coins
 
--- | From the given list of coins, remove dust coins with a value less than or
---   equal to the given threshold value, redistributing their total value over
---   the coins that remain.
+-- From the given list of coins, remove dust coins with a value less than or
+-- equal to the given threshold value, redistributing their total value over
+-- the coins that remain.
 --
 -- This function satisfies the following properties:
 --
@@ -430,7 +428,8 @@ coalesceDust (DustThreshold threshold) coins =
     (coinsToKeep, coinsToRemove) = NE.partition (> threshold) coins
     valueToDistribute = F.fold coinsToRemove
 
--- | Computes how much is left to pay given a particular selection
+-- Computes how much is left to pay given a particular selection.
+--
 remainingFee
     :: (HasCallStack, Show i, Show o)
     => FeeEstimator i o
@@ -461,10 +460,10 @@ remainingFee FeeEstimator {estimateFee} s
     errorUnderfundedSelection = error
         "Cannot calculate remaining fee for an underfunded selection."
 
--- | Splits up the given coin of value __@v@__, distributing its value over the
---   given coin list of length __@n@__, so that each coin value is increased by
---   an integral amount within unity of __@v/n@__, producing a new list of coin
---   values where the overall total is preserved.
+-- Splits up the given coin of value __@v@__, distributing its value over the
+-- given coin list of length __@n@__, so that each coin value is increased by
+-- an integral amount within unity of __@v/n@__, producing a new list of coin
+-- values where the overall total is preserved.
 --
 -- == Basic Examples
 --
@@ -521,11 +520,7 @@ splitCoin coinToSplit coinsToIncrease =
     mIncrement = coinToSplit `C.div` mCoinCount
     mShortfall = coinToSplit `C.mod` mCoinCount
 
---------------------------------------------------------------------------------
--- Utilities
---------------------------------------------------------------------------------
-
--- | Extract the fractional part of a rational number.
+-- Extract the fractional part of a rational number.
 --
 -- Examples:
 --
@@ -538,10 +533,12 @@ splitCoin coinToSplit coinsToIncrease =
 fractionalPart :: Rational -> Rational
 fractionalPart = snd . properFraction @_ @Integer
 
--- | Apply the same function multiple times to a value.
+-- Apply the same function multiple times to a value.
 --
 applyN :: Int -> (a -> a) -> a -> a
 applyN n f = F.foldr (.) id (replicate n f)
 
+-- Find the sum of a list of entries.
+--
 sumEntries :: [CoinMapEntry i] -> Coin
 sumEntries = F.fold . fmap entryValue

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -101,7 +101,7 @@ newtype Fee = Fee { unFee :: Coin }
 -- | Defines the maximum size of a dust coin.
 --
 -- Change values that are less than or equal to this threshold will not be
--- included in coin selections.
+-- included in coin selections produced by the 'adjustForFee' function.
 --
 newtype DustThreshold = DustThreshold { unDustThreshold :: Coin }
     deriving stock (Eq, Generic, Ord)

--- a/src/library/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/library/Cardano/CoinSelection/LargestFirst.hs
@@ -19,7 +19,7 @@ import Cardano.CoinSelection
     , CoinSelection (..)
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
-    , CoinSelectionInputLimit (..)
+    , CoinSelectionLimit (..)
     , CoinSelectionParameters (..)
     , CoinSelectionResult (..)
     , coinMapFromList

--- a/src/library/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/library/Cardano/CoinSelection/LargestFirst.hs
@@ -20,7 +20,7 @@ import Cardano.CoinSelection
     , CoinSelection (..)
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
-    , CoinSelectionOptions (..)
+    , CoinSelectionInputLimit (..)
     , coinMapFromList
     , coinMapToList
     , coinMapValue
@@ -167,7 +167,7 @@ import qualified Internal.Coin as C
 --      See: __'ErrUtxoFullyDepleted'__.
 --
 --  4.  The /number/ of UTxO entries needed to pay for the requested outputs
---      would /exceed/ the upper limit specified by 'maximumInputCount'.
+--      would /exceed/ the upper limit specified by 'calculateInputLimit'.
 --
 --      See: __'ErrMaximumInputCountExceeded'__.
 --
@@ -178,7 +178,7 @@ largestFirst = CoinSelectionAlgorithm payForOutputs
 
 payForOutputs
     :: (Ord i, Ord o, Monad m)
-    => CoinSelectionOptions
+    => CoinSelectionInputLimit
     -> CoinMap i
     -> CoinMap o
     -> ExceptT CoinSelectionError m (CoinSelection i o, CoinMap i)
@@ -203,7 +203,7 @@ payForOutputs options utxo outputsRequested =
     amountRequested =
         coinMapValue outputsRequested
     inputCountMax =
-        fromIntegral $ maximumInputCount options $ fromIntegral outputCount
+        fromIntegral $ calculateInputLimit options $ fromIntegral outputCount
     outputCount =
         fromIntegral $ length $ coinMapToList outputsRequested
     outputsDescending =

--- a/src/library/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/library/Cardano/CoinSelection/LargestFirst.hs
@@ -170,7 +170,7 @@ import qualified Internal.Coin as C
 --  4.  The /number/ of UTxO entries needed to pay for the requested outputs
 --      would /exceed/ the upper limit specified by 'limit'.
 --
---      See: __'ErrMaximumInputCountExceeded'__.
+--      See: __'ErrLimitExceeded'__.
 --
 largestFirst
     :: (Ord i, Ord o, Monad m)
@@ -196,7 +196,7 @@ payForOutputs params =
       | utxoCount <= inputCountMax =
           ErrUtxoFullyDepleted
       | otherwise =
-          ErrMaximumInputCountExceeded inputCountMax
+          ErrLimitExceeded inputCountMax
     amountAvailable =
         coinMapValue $ inputsAvailable params
     amountRequested =

--- a/src/library/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/library/Cardano/CoinSelection/LargestFirst.hs
@@ -168,7 +168,7 @@ import qualified Internal.Coin as C
 --      See: __'ErrUtxoFullyDepleted'__.
 --
 --  4.  The /number/ of UTxO entries needed to pay for the requested outputs
---      would /exceed/ the upper limit specified by 'inputLimit'.
+--      would /exceed/ the upper limit specified by 'limit'.
 --
 --      See: __'ErrMaximumInputCountExceeded'__.
 --
@@ -202,7 +202,7 @@ payForOutputs params =
     amountRequested =
         coinMapValue $ outputsRequested params
     inputCountMax = fromIntegral
-        $ calculateInputLimit (inputLimit params)
+        $ calculateLimit (limit params)
         $ fromIntegral outputCount
     outputCount =
         fromIntegral $ length $ coinMapToList $ outputsRequested params

--- a/src/library/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/library/Cardano/CoinSelection/LargestFirst.hs
@@ -168,7 +168,7 @@ import qualified Internal.Coin as C
 --      See: __'ErrUtxoFullyDepleted'__.
 --
 --  4.  The /number/ of UTxO entries needed to pay for the requested outputs
---      would /exceed/ the upper limit specified by 'calculateInputLimit'.
+--      would /exceed/ the upper limit specified by 'inputLimit'.
 --
 --      See: __'ErrMaximumInputCountExceeded'__.
 --

--- a/src/library/Cardano/CoinSelection/LargestFirst.hs
+++ b/src/library/Cardano/CoinSelection/LargestFirst.hs
@@ -15,13 +15,13 @@ module Cardano.CoinSelection.LargestFirst (
 import Prelude
 
 import Cardano.CoinSelection
-    ( CoinMap (..)
-    , CoinMapEntry (..)
+    ( CoinMapEntry (..)
     , CoinSelection (..)
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
     , CoinSelectionInputLimit (..)
     , CoinSelectionParameters (..)
+    , CoinSelectionResult (..)
     , coinMapFromList
     , coinMapToList
     , coinMapValue
@@ -180,11 +180,11 @@ largestFirst = CoinSelectionAlgorithm payForOutputs
 payForOutputs
     :: (Ord i, Ord o, Monad m)
     => CoinSelectionParameters i o
-    -> ExceptT CoinSelectionError m (CoinSelection i o, CoinMap i)
+    -> ExceptT CoinSelectionError m (CoinSelectionResult i o)
 payForOutputs params =
     case foldM payForOutput (utxoDescending, mempty) outputsDescending of
         Just (utxoRemaining, selection) ->
-            pure (selection, coinMapFromList utxoRemaining)
+            pure $ CoinSelectionResult selection $ coinMapFromList utxoRemaining
         Nothing ->
             throwE errorCondition
   where

--- a/src/library/Cardano/CoinSelection/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Migration.hs
@@ -34,7 +34,7 @@
 -- that a wallet is not "fragmented enough").
 
 module Cardano.CoinSelection.Migration
-    ( depleteUTxO
+    ( selectCoins
     , idealBatchSize
     ) where
 
@@ -75,7 +75,7 @@ import qualified Internal.Coin as C
 --
 -- The fee options are used to balance the coin selections and fix a threshold
 -- for dust that is removed from the selections.
-depleteUTxO
+selectCoins
     :: forall i o . (Ord i, Ord o)
     => FeeOptions i o
         -- ^ Fee computation and threshold definition
@@ -84,7 +84,7 @@ depleteUTxO
     -> CoinMap i
         -- ^ UTxO to deplete
     -> [CoinSelection i o]
-depleteUTxO feeOpts batchSize utxo =
+selectCoins feeOpts batchSize utxo =
     evalState migrate (coinMapToList utxo)
   where
     migrate :: State [CoinMapEntry i] [CoinSelection i o]

--- a/src/library/Cardano/CoinSelection/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Migration.hs
@@ -50,7 +50,7 @@ import Cardano.CoinSelection
     ( CoinMap
     , CoinMapEntry (..)
     , CoinSelection (..)
-    , CoinSelectionOptions (..)
+    , CoinSelectionInputLimit (..)
     , coinMapFromList
     , coinMapToList
     , sumChange
@@ -190,7 +190,7 @@ selectCoins feeOpts batchSize utxo =
 
 -- Try to find a fixed "ideal" number of input transactions that would generate
 -- relatively balanced transactions.
-idealBatchSize :: CoinSelectionOptions -> Word8
+idealBatchSize :: CoinSelectionInputLimit -> Word8
 idealBatchSize coinselOpts = fixPoint 1
   where
     fixPoint :: Word8 -> Word8
@@ -200,4 +200,4 @@ idealBatchSize coinselOpts = fixPoint 1
         | otherwise = fixPoint (n + 1)
       where
         maxN :: Word8 -> Word8
-        maxN = maximumInputCount coinselOpts
+        maxN = calculateInputLimit coinselOpts

--- a/src/library/Cardano/CoinSelection/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Migration.hs
@@ -200,4 +200,4 @@ idealBatchSize coinselOpts = fixPoint 1
         | otherwise = fixPoint (n + 1)
       where
         maxN :: Word8 -> Word8
-        maxN = calculateInputLimit coinselOpts
+        maxN = calculateLimit coinselOpts

--- a/src/library/Cardano/CoinSelection/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Migration.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_HADDOCK prune #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -34,8 +35,13 @@
 -- that a wallet is not "fragmented enough").
 
 module Cardano.CoinSelection.Migration
-    ( selectCoins
+    (
+      -- * Coin Selection for Migration
+      selectCoins
+
+      -- # Internal Functions
     , idealBatchSize
+
     ) where
 
 import Prelude
@@ -64,6 +70,10 @@ import Internal.Coin
     ( Coin, coinFromIntegral, coinToIntegral )
 
 import qualified Internal.Coin as C
+
+--------------------------------------------------------------------------------
+-- Coin Selection for Migration
+--------------------------------------------------------------------------------
 
 -- | Construct a list of coin selections / transactions to transfer the totality
 -- of a user's wallet. The resulting 'CoinSelection' do not contain any
@@ -174,8 +184,12 @@ selectCoins feeOpts batchSize utxo =
         put rest
         pure batch
 
--- | Try to find a fix "ideal" number of input transactions that would generate
--- rather balanced transactions.
+--------------------------------------------------------------------------------
+-- Internal Functions
+--------------------------------------------------------------------------------
+
+-- Try to find a fixed "ideal" number of input transactions that would generate
+-- relatively balanced transactions.
 idealBatchSize :: CoinSelectionOptions i o e -> Word8
 idealBatchSize coinselOpts = fixPoint 1
   where

--- a/src/library/Cardano/CoinSelection/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Migration.hs
@@ -190,7 +190,7 @@ selectCoins feeOpts batchSize utxo =
 
 -- Try to find a fixed "ideal" number of input transactions that would generate
 -- relatively balanced transactions.
-idealBatchSize :: CoinSelectionOptions i o e -> Word8
+idealBatchSize :: CoinSelectionOptions -> Word8
 idealBatchSize coinselOpts = fixPoint 1
   where
     fixPoint :: Word8 -> Word8

--- a/src/library/Cardano/CoinSelection/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Migration.hs
@@ -50,7 +50,7 @@ import Cardano.CoinSelection
     ( CoinMap
     , CoinMapEntry (..)
     , CoinSelection (..)
-    , CoinSelectionInputLimit (..)
+    , CoinSelectionLimit (..)
     , coinMapFromList
     , coinMapToList
     , sumChange
@@ -190,7 +190,7 @@ selectCoins feeOpts batchSize utxo =
 
 -- Try to find a fixed "ideal" number of input transactions that would generate
 -- relatively balanced transactions.
-idealBatchSize :: CoinSelectionInputLimit -> Word8
+idealBatchSize :: CoinSelectionLimit -> Word8
 idealBatchSize coinselOpts = fixPoint 1
   where
     fixPoint :: Word8 -> Word8

--- a/src/library/Cardano/CoinSelection/RandomImprove.hs
+++ b/src/library/Cardano/CoinSelection/RandomImprove.hs
@@ -22,7 +22,7 @@ import Cardano.CoinSelection
     , CoinSelection (..)
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
-    , CoinSelectionInputLimit (..)
+    , CoinSelectionLimit (..)
     , CoinSelectionParameters (..)
     , CoinSelectionResult (..)
     , coinMapFromList

--- a/src/library/Cardano/CoinSelection/RandomImprove.hs
+++ b/src/library/Cardano/CoinSelection/RandomImprove.hs
@@ -24,6 +24,7 @@ import Cardano.CoinSelection
     , CoinSelectionError (..)
     , CoinSelectionInputLimit (..)
     , CoinSelectionParameters (..)
+    , CoinSelectionResult (..)
     , coinMapFromList
     , coinMapRandomEntry
     , coinMapToList
@@ -209,7 +210,7 @@ randomImprove = CoinSelectionAlgorithm payForOutputs
 payForOutputs
     :: (Ord i, Ord o, MonadRandom m)
     => CoinSelectionParameters i o
-    -> ExceptT CoinSelectionError m (CoinSelection i o, CoinMap i)
+    -> ExceptT CoinSelectionError m (CoinSelectionResult i o)
 payForOutputs params = do
     mRandomSelections <- lift $ runMaybeT $ foldM makeRandomSelection
         (inputCountMax, inputsAvailable params, []) outputsDescending
@@ -219,7 +220,7 @@ payForOutputs params = do
                 improveSelection
                     (inputCountRemaining, mempty, utxoRemaining)
                     (reverse randomSelections)
-            pure (finalSelection, utxoRemaining')
+            pure $ CoinSelectionResult finalSelection utxoRemaining'
         Nothing ->
             throwE errorCondition
   where

--- a/src/library/Cardano/CoinSelection/RandomImprove.hs
+++ b/src/library/Cardano/CoinSelection/RandomImprove.hs
@@ -22,7 +22,7 @@ import Cardano.CoinSelection
     , CoinSelection (..)
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
-    , CoinSelectionOptions (..)
+    , CoinSelectionInputLimit (..)
     , coinMapFromList
     , coinMapRandomEntry
     , coinMapToList
@@ -118,7 +118,7 @@ import qualified Internal.Coin as C
 --
 --       * __Condition 3__: when counting cumulatively across all outputs
 --       considered so far, we have not selected more than the /maximum/ number
---       of UTxO entries specified by 'maximumInputCount'.
+--       of UTxO entries specified by 'calculateInputLimit'.
 --
 --  3.  __Creates a /change value/__ for the output, equal to the total value
 --      of the /final UTxO selection/ for that output minus the value /v/ of
@@ -165,7 +165,7 @@ import qualified Internal.Coin as C
 --      See: __'ErrUtxoFullyDepleted'__.
 --
 --  4.  The /number/ of UTxO entries needed to pay for the requested outputs
---      would /exceed/ the upper limit specified by 'maximumInputCount'.
+--      would /exceed/ the upper limit specified by 'calculateInputLimit'.
 --
 --      See: __'ErrMaximumInputCountExceeded'__.
 --
@@ -207,7 +207,7 @@ randomImprove = CoinSelectionAlgorithm payForOutputs
 
 payForOutputs
     :: (Ord i, Ord o, MonadRandom m)
-    => CoinSelectionOptions
+    => CoinSelectionInputLimit
     -> CoinMap i
     -> CoinMap o
     -> ExceptT CoinSelectionError m (CoinSelection i o, CoinMap i)
@@ -239,7 +239,7 @@ payForOutputs options utxo outputsRequested = do
     amountRequested =
         coinMapValue outputsRequested
     inputCountMax =
-        fromIntegral $ maximumInputCount options $ fromIntegral outputCount
+        fromIntegral $ calculateInputLimit options $ fromIntegral outputCount
     outputCount =
         fromIntegral $ length $ coinMapToList outputsRequested
     outputsDescending =

--- a/src/library/Cardano/CoinSelection/RandomImprove.hs
+++ b/src/library/Cardano/CoinSelection/RandomImprove.hs
@@ -120,7 +120,7 @@ import qualified Internal.Coin as C
 --
 --       * __Condition 3__: when counting cumulatively across all outputs
 --       considered so far, we have not selected more than the /maximum/ number
---       of UTxO entries specified by 'inputLimit'.
+--       of UTxO entries specified by 'limit'.
 --
 --  3.  __Creates a /change value/__ for the output, equal to the total value
 --      of the /final UTxO selection/ for that output minus the value /v/ of
@@ -167,7 +167,7 @@ import qualified Internal.Coin as C
 --      See: __'ErrUtxoFullyDepleted'__.
 --
 --  4.  The /number/ of UTxO entries needed to pay for the requested outputs
---      would /exceed/ the upper limit specified by 'inputLimit'.
+--      would /exceed/ the upper limit specified by 'limit'.
 --
 --      See: __'ErrMaximumInputCountExceeded'__.
 --
@@ -239,7 +239,7 @@ payForOutputs params = do
     amountRequested =
         coinMapValue $ outputsRequested params
     inputCountMax = fromIntegral
-        $ calculateInputLimit (inputLimit params)
+        $ calculateLimit (limit params)
         $ fromIntegral outputCount
     outputCount =
         fromIntegral $ length $ coinMapToList $ outputsRequested params

--- a/src/library/Cardano/CoinSelection/RandomImprove.hs
+++ b/src/library/Cardano/CoinSelection/RandomImprove.hs
@@ -169,7 +169,7 @@ import qualified Internal.Coin as C
 --  4.  The /number/ of UTxO entries needed to pay for the requested outputs
 --      would /exceed/ the upper limit specified by 'limit'.
 --
---      See: __'ErrMaximumInputCountExceeded'__.
+--      See: __'ErrLimitExceeded'__.
 --
 -- = Motivating Principles
 --
@@ -233,7 +233,7 @@ payForOutputs params = do
       | utxoCount <= inputCountMax =
           ErrUtxoFullyDepleted
       | otherwise =
-          ErrMaximumInputCountExceeded (fromIntegral inputCountMax)
+          ErrLimitExceeded (fromIntegral inputCountMax)
     amountAvailable =
         coinMapValue $ inputsAvailable params
     amountRequested =

--- a/src/library/Cardano/CoinSelection/RandomImprove.hs
+++ b/src/library/Cardano/CoinSelection/RandomImprove.hs
@@ -120,7 +120,7 @@ import qualified Internal.Coin as C
 --
 --       * __Condition 3__: when counting cumulatively across all outputs
 --       considered so far, we have not selected more than the /maximum/ number
---       of UTxO entries specified by 'calculateInputLimit'.
+--       of UTxO entries specified by 'inputLimit'.
 --
 --  3.  __Creates a /change value/__ for the output, equal to the total value
 --      of the /final UTxO selection/ for that output minus the value /v/ of
@@ -167,7 +167,7 @@ import qualified Internal.Coin as C
 --      See: __'ErrUtxoFullyDepleted'__.
 --
 --  4.  The /number/ of UTxO entries needed to pay for the requested outputs
---      would /exceed/ the upper limit specified by 'calculateInputLimit'.
+--      would /exceed/ the upper limit specified by 'inputLimit'.
 --
 --      See: __'ErrMaximumInputCountExceeded'__.
 --

--- a/src/test/Cardano/CoinSelection/FeeSpec.hs
+++ b/src/test/Cardano/CoinSelection/FeeSpec.hs
@@ -32,8 +32,8 @@ import Cardano.CoinSelection
     )
 import Cardano.CoinSelection.Fee
     ( DustThreshold (..)
-    , FeeAdjustmentError (..)
     , Fee (..)
+    , FeeAdjustmentError (..)
     , FeeEstimator (..)
     , FeeOptions (..)
     , adjustForFee
@@ -905,7 +905,7 @@ genSelection
     => CoinMap o
     -> Gen (CoinSelection i o)
 genSelection outs = do
-    let opts = CS.CoinSelectionOptions (const 100) (const $ pure ())
+    let opts = CS.CoinSelectionOptions (const 100)
     utxo <- vectorOf (length outs * 3) arbitrary >>= genInputs
     case runIdentity $ runExceptT $ selectCoins largestFirst opts utxo outs of
         Left _ -> genSelection outs

--- a/src/test/Cardano/CoinSelection/FeeSpec.hs
+++ b/src/test/Cardano/CoinSelection/FeeSpec.hs
@@ -907,7 +907,7 @@ genSelection
     -> Gen (CoinSelection i o)
 genSelection outs = do
     utxo <- vectorOf (length outs * 3) arbitrary >>= genInputs
-    let limit = CS.CoinSelectionInputLimit $ const 100
+    let limit = CS.CoinSelectionLimit $ const 100
     let params = CS.CoinSelectionParameters limit utxo outs
     case runIdentity $ runExceptT $ selectCoins largestFirst params of
         Left _ -> genSelection outs

--- a/src/test/Cardano/CoinSelection/FeeSpec.hs
+++ b/src/test/Cardano/CoinSelection/FeeSpec.hs
@@ -905,7 +905,7 @@ genSelection
     => CoinMap o
     -> Gen (CoinSelection i o)
 genSelection outs = do
-    let opts = CS.CoinSelectionOptions (const 100)
+    let opts = CS.CoinSelectionInputLimit (const 100)
     utxo <- vectorOf (length outs * 3) arbitrary >>= genInputs
     case runIdentity $ runExceptT $ selectCoins largestFirst opts utxo outs of
         Left _ -> genSelection outs

--- a/src/test/Cardano/CoinSelection/FeeSpec.hs
+++ b/src/test/Cardano/CoinSelection/FeeSpec.hs
@@ -907,8 +907,8 @@ genSelection
     -> Gen (CoinSelection i o)
 genSelection outs = do
     utxo <- vectorOf (length outs * 3) arbitrary >>= genInputs
-    let limit = CS.CoinSelectionLimit $ const 100
-    let params = CS.CoinSelectionParameters limit utxo outs
+    let selectionLimit = CS.CoinSelectionLimit $ const 100
+    let params = CS.CoinSelectionParameters utxo outs selectionLimit
     case runIdentity $ runExceptT $ selectCoins largestFirst params of
         Left _ -> genSelection outs
         Right (CoinSelectionResult s _) -> return s

--- a/src/test/Cardano/CoinSelection/FeeSpec.hs
+++ b/src/test/Cardano/CoinSelection/FeeSpec.hs
@@ -905,9 +905,10 @@ genSelection
     => CoinMap o
     -> Gen (CoinSelection i o)
 genSelection outs = do
-    let opts = CS.CoinSelectionInputLimit (const 100)
     utxo <- vectorOf (length outs * 3) arbitrary >>= genInputs
-    case runIdentity $ runExceptT $ selectCoins largestFirst opts utxo outs of
+    let limit = CS.CoinSelectionInputLimit $ const 100
+    let params = CS.CoinSelectionParameters limit utxo outs
+    case runIdentity $ runExceptT $ selectCoins largestFirst params of
         Left _ -> genSelection outs
         Right (s,_) -> return s
 

--- a/src/test/Cardano/CoinSelection/FeeSpec.hs
+++ b/src/test/Cardano/CoinSelection/FeeSpec.hs
@@ -24,6 +24,7 @@ import Cardano.CoinSelection
     , CoinMapEntry (..)
     , CoinSelection (..)
     , CoinSelectionAlgorithm (..)
+    , CoinSelectionResult (..)
     , coinMapFromList
     , coinMapToList
     , sumChange
@@ -910,7 +911,7 @@ genSelection outs = do
     let params = CS.CoinSelectionParameters limit utxo outs
     case runIdentity $ runExceptT $ selectCoins largestFirst params of
         Left _ -> genSelection outs
-        Right (s,_) -> return s
+        Right (CoinSelectionResult s _) -> return s
 
 instance Arbitrary TxIn where
     shrink _ = []

--- a/src/test/Cardano/CoinSelection/FeeSpec.hs
+++ b/src/test/Cardano/CoinSelection/FeeSpec.hs
@@ -32,7 +32,7 @@ import Cardano.CoinSelection
     )
 import Cardano.CoinSelection.Fee
     ( DustThreshold (..)
-    , ErrAdjustForFee (..)
+    , FeeAdjustmentError (..)
     , Fee (..)
     , FeeEstimator (..)
     , FeeOptions (..)
@@ -817,7 +817,7 @@ feeOptions fee dust = FeeOptions
 
 feeUnitTest
     :: FeeFixture
-    -> Either ErrAdjustForFee FeeOutput
+    -> Either FeeAdjustmentError FeeOutput
     -> SpecWith ()
 feeUnitTest (FeeFixture inpsF outsF chngsF utxoF feeF dustF) expected =
     it title $ do

--- a/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -15,7 +15,7 @@ import Cardano.CoinSelection
     , CoinSelection (..)
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
-    , CoinSelectionOptions (..)
+    , CoinSelectionInputLimit (..)
     , coinMapToList
     )
 import Cardano.CoinSelection.LargestFirst
@@ -212,7 +212,7 @@ propAtLeast (CoinSelProp utxo txOuts) =
     prop (CoinSelection inps _ _) =
         length inps `shouldSatisfy` (>= length txOuts)
     selection = runIdentity $ runExceptT $ selectCoins
-        largestFirst (CoinSelectionOptions (const 100)) utxo txOuts
+        largestFirst (CoinSelectionInputLimit (const 100)) utxo txOuts
 
 propInputDecreasingOrder
     :: (Ord i, Ord o)
@@ -230,4 +230,4 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
             `shouldSatisfy`
             (>= (L.maximum (snd <$> utxo')))
     selection = runIdentity $ runExceptT $ selectCoins largestFirst
-        (CoinSelectionOptions (const 100)) utxo txOuts
+        (CoinSelectionInputLimit (const 100)) utxo txOuts

--- a/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -163,7 +163,7 @@ spec = do
         coinSelectionUnitTest largestFirst
             "UTxO balance sufficient, fragmented enough, but maximum input \
             \count exceeded"
-            (Left $ ErrMaximumInputCountExceeded 9)
+            (Left $ ErrLimitExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , utxoInputs = replicate 100 1
@@ -173,7 +173,7 @@ spec = do
         coinSelectionUnitTest largestFirst
             "UTxO balance sufficient, fragmented enough, but maximum input \
             \count exceeded"
-            (Left $ ErrMaximumInputCountExceeded 9)
+            (Left $ ErrLimitExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , utxoInputs = replicate 100 1
@@ -183,7 +183,7 @@ spec = do
         coinSelectionUnitTest largestFirst
             "UTxO balance sufficient, fragmented enough, but maximum input \
             \count exceeded"
-            (Left $ ErrMaximumInputCountExceeded 2)
+            (Left $ ErrLimitExceeded 2)
             (CoinSelectionFixture
                 { maxNumOfInputs = 2
                 , utxoInputs = [1,2,10,6,5]

--- a/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -16,6 +16,7 @@ import Cardano.CoinSelection
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
     , CoinSelectionInputLimit (..)
+    , CoinSelectionParameters (..)
     , coinMapToList
     )
 import Cardano.CoinSelection.LargestFirst
@@ -211,8 +212,9 @@ propAtLeast (CoinSelProp utxo txOuts) =
   where
     prop (CoinSelection inps _ _) =
         length inps `shouldSatisfy` (>= length txOuts)
-    selection = runIdentity $ runExceptT $ selectCoins
-        largestFirst (CoinSelectionInputLimit (const 100)) utxo txOuts
+    selection = runIdentity $ runExceptT $ selectCoins largestFirst
+        $ CoinSelectionParameters limit utxo txOuts
+    limit = CoinSelectionInputLimit $ const 100
 
 propInputDecreasingOrder
     :: (Ord i, Ord o)
@@ -230,4 +232,5 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
             `shouldSatisfy`
             (>= (L.maximum (snd <$> utxo')))
     selection = runIdentity $ runExceptT $ selectCoins largestFirst
-        (CoinSelectionInputLimit (const 100)) utxo txOuts
+        $ CoinSelectionParameters limit utxo txOuts
+    limit = CoinSelectionInputLimit $ const 100

--- a/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -24,10 +24,7 @@ import Cardano.CoinSelectionSpec
     ( CoinSelProp (..)
     , CoinSelectionFixture (..)
     , CoinSelectionResult (..)
-    , ErrValidation (..)
-    , alwaysFail
     , coinSelectionUnitTest
-    , noValidation
     )
 import Cardano.Test.Utilities
     ( Address, TxIn, excluding, unsafeCoin )
@@ -60,7 +57,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [10,10,17]
                 , txOutputs = [17]
                 })
@@ -73,7 +69,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [12,10,17]
                 , txOutputs = [1]
                 })
@@ -86,7 +81,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [12,10,17]
                 , txOutputs = [18]
                 })
@@ -99,7 +93,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [12,10,17]
                 , txOutputs = [30]
                 })
@@ -112,7 +105,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 3
-                , validateSelection = noValidation
                 , utxoInputs = [1,2,10,6,5]
                 , txOutputs = [11, 1]
                 })
@@ -123,7 +115,6 @@ spec = do
                 (unsafeCoin @Int 39) (unsafeCoin @Int 40))
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [12,10,17]
                 , txOutputs = [40]
                 })
@@ -134,7 +125,6 @@ spec = do
                 (unsafeCoin @Int 39) (unsafeCoin @Int 43))
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [12,10,17]
                 , txOutputs = [40,1,1,1]
                 })
@@ -144,7 +134,6 @@ spec = do
             (Left $ ErrUtxoNotFragmentedEnough 3 4)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [12,20,17]
                 , txOutputs = [40,1,1,1]
                 })
@@ -155,7 +144,6 @@ spec = do
             (Left ErrUtxoFullyDepleted)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [12,20,17]
                 , txOutputs = [40, 1]
                 })
@@ -166,7 +154,6 @@ spec = do
             (Left ErrUtxoFullyDepleted)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [20,20,10,5]
                 , txOutputs = [41, 6]
                 })
@@ -177,7 +164,6 @@ spec = do
             (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
-                , validateSelection = noValidation
                 , utxoInputs = replicate 100 1
                 , txOutputs = replicate 100 1
                 })
@@ -188,7 +174,6 @@ spec = do
             (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
-                , validateSelection = noValidation
                 , utxoInputs = replicate 100 1
                 , txOutputs = replicate 10 10
                 })
@@ -199,19 +184,8 @@ spec = do
             (Left $ ErrMaximumInputCountExceeded 2)
             (CoinSelectionFixture
                 { maxNumOfInputs = 2
-                , validateSelection = noValidation
                 , utxoInputs = [1,2,10,6,5]
                 , txOutputs = [11, 1]
-                })
-
-        coinSelectionUnitTest largestFirst
-            "Custom validation test fails"
-            (Left $ ErrInvalidSelection ErrValidation)
-            (CoinSelectionFixture
-                { maxNumOfInputs = 100
-                , validateSelection = alwaysFail
-                , utxoInputs = [1,1]
-                , txOutputs = [2]
                 })
 
     describe "Coin selection: largest-first algorithm: properties" $ do
@@ -238,7 +212,7 @@ propAtLeast (CoinSelProp utxo txOuts) =
     prop (CoinSelection inps _ _) =
         length inps `shouldSatisfy` (>= length txOuts)
     selection = runIdentity $ runExceptT $ selectCoins
-        largestFirst (CoinSelectionOptions (const 100) noValidation) utxo txOuts
+        largestFirst (CoinSelectionOptions (const 100)) utxo txOuts
 
 propInputDecreasingOrder
     :: (Ord i, Ord o)
@@ -256,4 +230,4 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
             `shouldSatisfy`
             (>= (L.maximum (snd <$> utxo')))
     selection = runIdentity $ runExceptT $ selectCoins largestFirst
-        (CoinSelectionOptions (const 100) noValidation) utxo txOuts
+        (CoinSelectionOptions (const 100)) utxo txOuts

--- a/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -15,7 +15,7 @@ import Cardano.CoinSelection
     , CoinSelection (..)
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
-    , CoinSelectionInputLimit (..)
+    , CoinSelectionLimit (..)
     , CoinSelectionParameters (..)
     , CoinSelectionResult (..)
     , coinMapToList
@@ -217,7 +217,7 @@ propAtLeast (CoinSelProp utxo txOuts) =
         length inps `shouldSatisfy` (>= length txOuts)
     selection = runIdentity $ runExceptT $ selectCoins largestFirst
         $ CoinSelectionParameters limit utxo txOuts
-    limit = CoinSelectionInputLimit $ const 100
+    limit = CoinSelectionLimit $ const 100
 
 propInputDecreasingOrder
     :: (Ord i, Ord o)
@@ -240,4 +240,4 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
         $ runExceptT
         $ selectCoins largestFirst
         $ CoinSelectionParameters limit utxo txOuts
-    limit = CoinSelectionInputLimit $ const 100
+    limit = CoinSelectionLimit $ const 100

--- a/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -216,8 +216,8 @@ propAtLeast (CoinSelProp utxo txOuts) =
     prop (CoinSelection inps _ _) =
         length inps `shouldSatisfy` (>= length txOuts)
     selection = runIdentity $ runExceptT $ selectCoins largestFirst
-        $ CoinSelectionParameters limit utxo txOuts
-    limit = CoinSelectionLimit $ const 100
+        $ CoinSelectionParameters utxo txOuts selectionLimit
+    selectionLimit = CoinSelectionLimit $ const 100
 
 propInputDecreasingOrder
     :: (Ord i, Ord o)
@@ -239,5 +239,5 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
     selection = runIdentity
         $ runExceptT
         $ selectCoins largestFirst
-        $ CoinSelectionParameters limit utxo txOuts
-    limit = CoinSelectionLimit $ const 100
+        $ CoinSelectionParameters utxo txOuts selectionLimit
+    selectionLimit = CoinSelectionLimit $ const 100

--- a/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/LargestFirstSpec.hs
@@ -18,6 +18,10 @@ import Cardano.CoinSelection
     , CoinSelectionLimit (..)
     , CoinSelectionParameters (..)
     , CoinSelectionResult (..)
+    , InputCountInsufficientError (..)
+    , InputLimitExceededError (..)
+    , InputValueInsufficientError (..)
+    , InputsExhaustedError (..)
     , coinMapToList
     )
 import Cardano.CoinSelection.LargestFirst
@@ -113,7 +117,7 @@ spec = do
 
         coinSelectionUnitTest largestFirst
             "UTxO balance not sufficient"
-            (Left $ ErrUtxoBalanceInsufficient
+            (Left $ InputValueInsufficient $ InputValueInsufficientError
                 (unsafeCoin @Int 39) (unsafeCoin @Int 40))
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -123,7 +127,7 @@ spec = do
 
         coinSelectionUnitTest largestFirst
             "UTxO balance not sufficient, and not fragmented enough"
-            (Left $ ErrUtxoBalanceInsufficient
+            (Left $ InputValueInsufficient $ InputValueInsufficientError
                 (unsafeCoin @Int 39) (unsafeCoin @Int 43))
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -133,7 +137,7 @@ spec = do
 
         coinSelectionUnitTest largestFirst
             "UTxO balance sufficient, but not fragmented enough"
-            (Left $ ErrUtxoNotFragmentedEnough 3 4)
+            (Left $ InputCountInsufficient $ InputCountInsufficientError 3 4)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , utxoInputs = [12,20,17]
@@ -143,7 +147,7 @@ spec = do
         coinSelectionUnitTest largestFirst
             "UTxO balance sufficient, fragmented enough, but single output \
             \depletes all UTxO entries"
-            (Left ErrUtxoFullyDepleted)
+            (Left (InputsExhausted InputsExhaustedError))
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , utxoInputs = [12,20,17]
@@ -153,7 +157,7 @@ spec = do
         coinSelectionUnitTest largestFirst
             "UTxO balance sufficient, fragmented enough, but single output \
             \depletes all UTxO entries"
-            (Left ErrUtxoFullyDepleted)
+            (Left (InputsExhausted InputsExhaustedError))
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , utxoInputs = [20,20,10,5]
@@ -163,7 +167,7 @@ spec = do
         coinSelectionUnitTest largestFirst
             "UTxO balance sufficient, fragmented enough, but maximum input \
             \count exceeded"
-            (Left $ ErrLimitExceeded 9)
+            (Left $ InputLimitExceeded $ InputLimitExceededError 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , utxoInputs = replicate 100 1
@@ -173,7 +177,7 @@ spec = do
         coinSelectionUnitTest largestFirst
             "UTxO balance sufficient, fragmented enough, but maximum input \
             \count exceeded"
-            (Left $ ErrLimitExceeded 9)
+            (Left $ InputLimitExceeded $ InputLimitExceededError 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , utxoInputs = replicate 100 1
@@ -183,7 +187,7 @@ spec = do
         coinSelectionUnitTest largestFirst
             "UTxO balance sufficient, fragmented enough, but maximum input \
             \count exceeded"
-            (Left $ ErrLimitExceeded 2)
+            (Left $ InputLimitExceeded $ InputLimitExceededError 2)
             (CoinSelectionFixture
                 { maxNumOfInputs = 2
                 , utxoInputs = [1,2,10,6,5]

--- a/src/test/Cardano/CoinSelection/MigrationSpec.hs
+++ b/src/test/Cardano/CoinSelection/MigrationSpec.hs
@@ -26,7 +26,7 @@ import Cardano.CoinSelection.Fee
 import Cardano.CoinSelection.FeeSpec
     ()
 import Cardano.CoinSelection.Migration
-    ( selectCoins, idealBatchSize )
+    ( idealBatchSize, selectCoins )
 import Cardano.CoinSelectionSpec
     ()
 import Cardano.Test.Utilities
@@ -317,3 +317,7 @@ genUTxO r dust = do
         ]
       where
         integralDust = C.coinToIntegral dust
+
+--------------------------------------------------------------------------------
+-- Utility Functions
+--------------------------------------------------------------------------------

--- a/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -16,6 +16,10 @@ import Cardano.CoinSelection
     , CoinSelectionLimit (..)
     , CoinSelectionParameters (..)
     , CoinSelectionResult (..)
+    , InputCountInsufficientError (..)
+    , InputLimitExceededError (..)
+    , InputValueInsufficientError (..)
+    , InputsExhaustedError (..)
     )
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
@@ -150,7 +154,7 @@ spec = do
 
         coinSelectionUnitTest randomImprove
             "enough funds, proper fragmentation, inputs depleted"
-            (Left ErrUtxoFullyDepleted)
+            (Left (InputsExhausted InputsExhaustedError))
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , utxoInputs = [10,10,10,10]
@@ -158,7 +162,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove ""
-            (Left $ ErrLimitExceeded 2)
+            (Left $ InputLimitExceeded $ InputLimitExceededError 2)
             (CoinSelectionFixture
                 { maxNumOfInputs = 2
                 , utxoInputs = [1,1,1,1,1,1]
@@ -166,7 +170,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove "each output needs <maxNumOfInputs"
-            (Left $ ErrLimitExceeded 9)
+            (Left $ InputLimitExceeded $ InputLimitExceededError 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , utxoInputs = replicate 100 1
@@ -174,7 +178,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove "each output needs >maxNumInputs"
-            (Left $ ErrLimitExceeded 9)
+            (Left $ InputLimitExceeded $ InputLimitExceededError 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , utxoInputs = replicate 100 1
@@ -182,7 +186,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove ""
-            (Left $ ErrUtxoBalanceInsufficient
+            (Left $ InputValueInsufficient $ InputValueInsufficientError
                 (unsafeCoin @Int 39) (unsafeCoin @Int 40))
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -191,7 +195,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove ""
-            (Left $ ErrUtxoBalanceInsufficient
+            (Left $ InputValueInsufficient $ InputValueInsufficientError
                 (unsafeCoin @Int 39) (unsafeCoin @Int 43))
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -200,7 +204,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove ""
-            (Left $ ErrUtxoNotFragmentedEnough 3 4)
+            (Left $ InputCountInsufficient $ InputCountInsufficientError 3 4)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , utxoInputs = [12,20,17]

--- a/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -23,10 +23,7 @@ import Cardano.CoinSelectionSpec
     ( CoinSelProp (..)
     , CoinSelectionFixture (..)
     , CoinSelectionResult (..)
-    , ErrValidation (..)
-    , alwaysFail
     , coinSelectionUnitTest
-    , noValidation
     )
 import Cardano.Test.Utilities
     ( Address, TxIn, unsafeCoin )
@@ -60,7 +57,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [1,1,1,1,1,1]
                 , txOutputs = [2]
                 })
@@ -73,7 +69,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [1,1,1,1,1,1]
                 , txOutputs = [2,1]
                 })
@@ -86,7 +81,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [1,1,1,1,1]
                 , txOutputs = [2,1]
                 })
@@ -99,7 +93,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [1,1,1,1]
                 , txOutputs = [2,1]
                 })
@@ -112,7 +105,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [5,5,5]
                 , txOutputs = [2]
                 })
@@ -126,7 +118,6 @@ spec = do
             )
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [10,10,10]
                 , txOutputs = [2,2]
                 })
@@ -139,7 +130,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 4
-                , validateSelection = noValidation
                 , utxoInputs = [1,1,1,1,1,1]
                 , txOutputs = [3]
                 })
@@ -152,7 +142,6 @@ spec = do
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 4
-                , validateSelection = noValidation
                 , utxoInputs = [oneAda, oneAda, oneAda, oneAda]
                 , txOutputs = [2*oneAda, oneAda `div` 2]
                 })
@@ -162,7 +151,6 @@ spec = do
             (Left ErrUtxoFullyDepleted)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [10,10,10,10]
                 , txOutputs = [38,1]
                 })
@@ -171,7 +159,6 @@ spec = do
             (Left $ ErrMaximumInputCountExceeded 2)
             (CoinSelectionFixture
                 { maxNumOfInputs = 2
-                , validateSelection = noValidation
                 , utxoInputs = [1,1,1,1,1,1]
                 , txOutputs = [3]
                 })
@@ -180,7 +167,6 @@ spec = do
             (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
-                , validateSelection = noValidation
                 , utxoInputs = replicate 100 1
                 , txOutputs = replicate 100 1
                 })
@@ -189,7 +175,6 @@ spec = do
             (Left $ ErrMaximumInputCountExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
-                , validateSelection = noValidation
                 , utxoInputs = replicate 100 1
                 , txOutputs = replicate 10 10
                 })
@@ -199,7 +184,6 @@ spec = do
                 (unsafeCoin @Int 39) (unsafeCoin @Int 40))
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [12,10,17]
                 , txOutputs = [40]
                 })
@@ -209,7 +193,6 @@ spec = do
                 (unsafeCoin @Int 39) (unsafeCoin @Int 43))
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [12,10,17]
                 , txOutputs = [40,1,1,1]
                 })
@@ -218,18 +201,8 @@ spec = do
             (Left $ ErrUtxoNotFragmentedEnough 3 4)
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
-                , validateSelection = noValidation
                 , utxoInputs = [12,20,17]
                 , txOutputs = [40,1,1,1]
-                })
-
-        coinSelectionUnitTest randomImprove "custom validation"
-            (Left $ ErrInvalidSelection ErrValidation)
-            (CoinSelectionFixture
-                { maxNumOfInputs = 100
-                , validateSelection = alwaysFail
-                , utxoInputs = [1,1]
-                , txOutputs = [2]
                 })
 
     before getSystemDRG $
@@ -262,7 +235,7 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
         (runExceptT $ selectCoins randomImprove opt txOuts utxo)
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst opt txOuts utxo
-    opt = CoinSelectionOptions (const 100) noValidation
+    opt = CoinSelectionOptions (const 100)
 
 propErrors
     :: (Ord i, Ord o)
@@ -280,4 +253,4 @@ propErrors drg (CoinSelProp utxo txOuts) = do
         (runExceptT $ selectCoins randomImprove opt txOuts utxo)
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst opt txOuts utxo
-    opt = (CoinSelectionOptions (const 1) noValidation)
+    opt = CoinSelectionOptions (const 1)

--- a/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -158,7 +158,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove ""
-            (Left $ ErrMaximumInputCountExceeded 2)
+            (Left $ ErrLimitExceeded 2)
             (CoinSelectionFixture
                 { maxNumOfInputs = 2
                 , utxoInputs = [1,1,1,1,1,1]
@@ -166,7 +166,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove "each output needs <maxNumOfInputs"
-            (Left $ ErrMaximumInputCountExceeded 9)
+            (Left $ ErrLimitExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , utxoInputs = replicate 100 1
@@ -174,7 +174,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove "each output needs >maxNumInputs"
-            (Left $ ErrMaximumInputCountExceeded 9)
+            (Left $ ErrLimitExceeded 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
                 , utxoInputs = replicate 100 1

--- a/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -15,6 +15,7 @@ import Cardano.CoinSelection
     , CoinSelectionError (..)
     , CoinSelectionInputLimit (..)
     , CoinSelectionParameters (..)
+    , CoinSelectionResult (..)
     )
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
@@ -23,7 +24,7 @@ import Cardano.CoinSelection.RandomImprove
 import Cardano.CoinSelectionSpec
     ( CoinSelProp (..)
     , CoinSelectionFixture (..)
-    , CoinSelectionResult (..)
+    , CoinSelectionTestResult (..)
     , coinSelectionUnitTest
     )
 import Cardano.Test.Utilities
@@ -51,7 +52,7 @@ spec = do
         let oneAda = 1000000
 
         coinSelectionUnitTest randomImprove ""
-            (Right $ CoinSelectionResult
+            (Right $ CoinSelectionTestResult
                 { rsInputs = [1,1,1,1]
                 , rsChange = [2]
                 , rsOutputs = [2]
@@ -63,7 +64,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove ""
-            (Right $ CoinSelectionResult
+            (Right $ CoinSelectionTestResult
                 { rsInputs = [1,1,1,1,1,1]
                 , rsChange = [2,1]
                 , rsOutputs = [2,1]
@@ -75,7 +76,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove ""
-            (Right $ CoinSelectionResult
+            (Right $ CoinSelectionTestResult
                 { rsInputs = [1,1,1,1,1]
                 , rsChange = [2]
                 , rsOutputs = [2,1]
@@ -87,7 +88,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove ""
-            (Right $ CoinSelectionResult
+            (Right $ CoinSelectionTestResult
                 { rsInputs = [1,1,1,1]
                 , rsChange = [1]
                 , rsOutputs = [2,1]
@@ -99,7 +100,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove ""
-            (Right $ CoinSelectionResult
+            (Right $ CoinSelectionTestResult
                 { rsInputs = [5]
                 , rsChange = [3]
                 , rsOutputs = [2]
@@ -111,7 +112,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove ""
-            (Right $ CoinSelectionResult
+            (Right $ CoinSelectionTestResult
                 { rsInputs = [10,10]
                 , rsChange = [8,8]
                 , rsOutputs = [2,2]
@@ -124,7 +125,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove "cannot cover aim, but only min"
-            (Right $ CoinSelectionResult
+            (Right $ CoinSelectionTestResult
                 { rsInputs = [1,1,1,1]
                 , rsChange = [1]
                 , rsOutputs = [3]
@@ -136,7 +137,7 @@ spec = do
                 })
 
         coinSelectionUnitTest randomImprove "REG CO-450: no fallback"
-            (Right $ CoinSelectionResult
+            (Right $ CoinSelectionTestResult
                 { rsInputs = [oneAda, oneAda, oneAda, oneAda]
                 , rsChange = [oneAda, oneAda `div` 2]
                 , rsOutputs = [2*oneAda,oneAda `div` 2]
@@ -226,9 +227,9 @@ propFragmentation
     -> Property
 propFragmentation drg (CoinSelProp utxo txOuts) = do
     isRight selection1 && isRight selection2 ==>
-        let (Right (s1,_), Right (s2,_)) =
-                (selection1, selection2)
-        in prop (s1, s2)
+        let Right (CoinSelectionResult s1 _) = selection1 in
+        let Right (CoinSelectionResult s2 _) = selection2 in
+        prop (s1, s2)
   where
     prop (CoinSelection inps1 _ _, CoinSelection inps2 _ _) =
         L.length inps1 `shouldSatisfy` (>= L.length inps2)

--- a/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -13,7 +13,7 @@ import Cardano.CoinSelection
     ( CoinSelection (..)
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
-    , CoinSelectionOptions (..)
+    , CoinSelectionInputLimit (..)
     )
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
@@ -235,7 +235,7 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
         (runExceptT $ selectCoins randomImprove opt txOuts utxo)
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst opt txOuts utxo
-    opt = CoinSelectionOptions (const 100)
+    opt = CoinSelectionInputLimit (const 100)
 
 propErrors
     :: (Ord i, Ord o)
@@ -253,4 +253,4 @@ propErrors drg (CoinSelProp utxo txOuts) = do
         (runExceptT $ selectCoins randomImprove opt txOuts utxo)
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst opt txOuts utxo
-    opt = CoinSelectionOptions (const 1)
+    opt = CoinSelectionInputLimit (const 1)

--- a/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -14,6 +14,7 @@ import Cardano.CoinSelection
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
     , CoinSelectionInputLimit (..)
+    , CoinSelectionParameters (..)
     )
 import Cardano.CoinSelection.LargestFirst
     ( largestFirst )
@@ -231,11 +232,12 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
   where
     prop (CoinSelection inps1 _ _, CoinSelection inps2 _ _) =
         L.length inps1 `shouldSatisfy` (>= L.length inps2)
-    (selection1,_) = withDRG drg
-        (runExceptT $ selectCoins randomImprove opt txOuts utxo)
+    (selection1,_) = withDRG drg $
+        runExceptT $ selectCoins randomImprove params
     selection2 = runIdentity $ runExceptT $
-        selectCoins largestFirst opt txOuts utxo
-    opt = CoinSelectionInputLimit (const 100)
+        selectCoins largestFirst params
+    limit = CoinSelectionInputLimit $ const 100
+    params = CoinSelectionParameters limit txOuts utxo
 
 propErrors
     :: (Ord i, Ord o)
@@ -249,8 +251,9 @@ propErrors drg (CoinSelProp utxo txOuts) = do
   where
     prop (err1, err2) =
         err1 === err2
-    (selection1,_) = withDRG drg
-        (runExceptT $ selectCoins randomImprove opt txOuts utxo)
+    (selection1,_) = withDRG drg $
+        runExceptT $ selectCoins randomImprove params
     selection2 = runIdentity $ runExceptT $
-        selectCoins largestFirst opt txOuts utxo
-    opt = CoinSelectionInputLimit (const 1)
+        selectCoins largestFirst params
+    limit = CoinSelectionInputLimit $ const 1
+    params = CoinSelectionParameters limit txOuts utxo

--- a/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -237,8 +237,8 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
         runExceptT $ selectCoins randomImprove params
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst params
-    limit = CoinSelectionLimit $ const 100
-    params = CoinSelectionParameters limit txOuts utxo
+    selectionLimit = CoinSelectionLimit $ const 100
+    params = CoinSelectionParameters txOuts utxo selectionLimit
 
 propErrors
     :: (Ord i, Ord o)
@@ -256,5 +256,5 @@ propErrors drg (CoinSelProp utxo txOuts) = do
         runExceptT $ selectCoins randomImprove params
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst params
-    limit = CoinSelectionLimit $ const 1
-    params = CoinSelectionParameters limit txOuts utxo
+    selectionLimit = CoinSelectionLimit $ const 1
+    params = CoinSelectionParameters txOuts utxo selectionLimit

--- a/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/RandomImproveSpec.hs
@@ -13,7 +13,7 @@ import Cardano.CoinSelection
     ( CoinSelection (..)
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
-    , CoinSelectionInputLimit (..)
+    , CoinSelectionLimit (..)
     , CoinSelectionParameters (..)
     , CoinSelectionResult (..)
     )
@@ -237,7 +237,7 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
         runExceptT $ selectCoins randomImprove params
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst params
-    limit = CoinSelectionInputLimit $ const 100
+    limit = CoinSelectionLimit $ const 100
     params = CoinSelectionParameters limit txOuts utxo
 
 propErrors
@@ -256,5 +256,5 @@ propErrors drg (CoinSelProp utxo txOuts) = do
         runExceptT $ selectCoins randomImprove params
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst params
-    limit = CoinSelectionInputLimit $ const 1
+    limit = CoinSelectionLimit $ const 1
     params = CoinSelectionParameters limit txOuts utxo

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -334,7 +334,7 @@ coinSelectionUnitTest alg lbl expected (CoinSelectionFixture n utxoF outsF) =
         result <- runExceptT $ do
             CoinSelectionResult (CoinSelection inps outs chngs) _ <-
                 selectCoins alg $
-                    CoinSelectionParameters maxInputCount utxo txOuts
+                    CoinSelectionParameters utxo txOuts selectionLimit
             return $ CoinSelectionTestResult
                 { rsInputs = coinToIntegral . entryValue <$> coinMapToList inps
                 , rsChange = coinToIntegral <$> chngs
@@ -343,7 +343,7 @@ coinSelectionUnitTest alg lbl expected (CoinSelectionFixture n utxoF outsF) =
         fmap sortCoinSelectionTestResult result
             `shouldBe` fmap sortCoinSelectionTestResult expected
   where
-    maxInputCount = CoinSelectionLimit $ const n
+    selectionLimit = CoinSelectionLimit $ const n
 
     title :: String
     title = mempty

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -30,7 +30,7 @@ import Cardano.CoinSelection
     , CoinSelection (..)
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
-    , CoinSelectionInputLimit (..)
+    , CoinSelectionLimit (..)
     , CoinSelectionParameters (..)
     , CoinSelectionResult (..)
     , coinMapFromList
@@ -343,7 +343,7 @@ coinSelectionUnitTest alg lbl expected (CoinSelectionFixture n utxoF outsF) =
         fmap sortCoinSelectionTestResult result
             `shouldBe` fmap sortCoinSelectionTestResult expected
   where
-    maxInputCount = CoinSelectionInputLimit $ const n
+    maxInputCount = CoinSelectionLimit $ const n
 
     title :: String
     title = mempty
@@ -374,7 +374,7 @@ instance (Arbitrary i, Arbitrary o, Ord i, Ord o) =>
         <*> arbitrary
     shrink = genericShrink
 
-instance Arbitrary (CoinSelectionInputLimit) where
+instance Arbitrary (CoinSelectionLimit) where
     arbitrary = do
         -- NOTE Functions have to be decreasing functions
         fn <- elements
@@ -385,10 +385,10 @@ instance Arbitrary (CoinSelectionInputLimit) where
                     else maxBound - (2 * x)
             , const 42
             ]
-        pure $ CoinSelectionInputLimit fn
+        pure $ CoinSelectionLimit fn
 
-instance Show (CoinSelectionInputLimit) where
-    show _ = "CoinSelectionInputLimit"
+instance Show (CoinSelectionLimit) where
+    show _ = "CoinSelectionLimit"
 
 instance Arbitrary a => Arbitrary (NonEmpty a) where
     shrink xs = catMaybes (NE.nonEmpty <$> shrink (NE.toList xs))

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -31,6 +31,7 @@ import Cardano.CoinSelection
     , CoinSelectionAlgorithm (..)
     , CoinSelectionError (..)
     , CoinSelectionInputLimit (..)
+    , CoinSelectionParameters (..)
     , coinMapFromList
     , coinMapToList
     , coinMapValue
@@ -329,8 +330,8 @@ coinSelectionUnitTest alg lbl expected (CoinSelectionFixture n utxoF outsF) =
     it title $ do
         (utxo,txOuts) <- setup
         result <- runExceptT $ do
-            (CoinSelection inps outs chngs, _) <-
-                selectCoins alg maxInputCount utxo txOuts
+            (CoinSelection inps outs chngs, _) <- selectCoins alg $
+                CoinSelectionParameters maxInputCount utxo txOuts
             return $ CoinSelectionResult
                 { rsInputs = coinToIntegral . entryValue <$> coinMapToList inps
                 , rsChange = coinToIntegral <$> chngs


### PR DESCRIPTION
## Related Issue

#18 
#30 

## Summary

This PR makes a number of changes aimed at improving the public API and documentation:

- [x] Revises the overall structure of the documentation for the main `CoinSelection` module.
- [x] Uses `OPTIONS_HADDOCK prune` to hide internal functions from Haddock documentation.
- [x] Gives each error condition its own separate type. Advantages:
    - [x] Parameters to errors can be named, making `Show` instances more informative.
    - [x] The documentation for each error can be more informative, as it can be separated into paragraphs (rather than squashed into a table cell).
- [x] Removes user-defined validation. If a caller wishes to validate a generated `CoinSelection`, they can easily validate it themselves after calling `selectCoins`.
