### PR TITLE
ignore automatically derived instances and record accessors in coverage

### DIFF
--- a/.coverage/template.overlay
+++ b/.coverage/template.overlay
@@ -1,0 +1,38 @@
+module "Internal.Coin" {
+  tick "getSum" [Record accessor];
+  tick "unCoin" [Record accessor];
+  tick function "==" [derived Eq instance];
+  tick function "compare" [derived Ord instance];
+  tick function "showsPrec" [derived Show instance];
+}
+
+module "Internal.Invariant" {
+  inside "invariant" {
+    tick "error msg" [Never executed invariant];
+  }
+}
+
+module "Internal.Rounding" {
+  tick function "==" [derived Eq instance];
+  tick function "showsPrec" [derived Show instance];
+}
+
+module "Cardano.CoinSelection" {
+  tick function "==" [derived Eq instance];
+  tick function "showsPrec" [derived Show instance];
+
+  tick "calculatedInputLimit" [Record accessor];
+  tick "inputCountAvailable" [Record accessor];
+  tick "inputCountRequired" [Record accessor];
+  tick "inputValueAvailable" [Record accessor];
+  tick "inputValueRequired" [Record accessor];
+  tick "coinSelection" [Record accessor];
+  tick "inputsRemaining" [Record accessor];
+}
+
+module "Cardano.CoinSelection.Fee" {
+  tick function "<>" [derived Monoid instance];
+  tick function "==" [derived Eq instance];
+  tick function "compare" [derived Ord instance];
+  tick function "showsPrec" [derived Show instance];
+}


### PR DESCRIPTION
These things are just creating noise in the coverage reports. With some overlay, we can better target which part of the code needs coverage. With this, we get to:


![badge](https://user-images.githubusercontent.com/5680256/80009618-9b7a5500-84c9-11ea-9bbb-2ac519e98796.png)
