### PR TITLE
Widen `CoinSelectionLimit` to `Word16`.

### DIFF
--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -69,7 +69,7 @@ import Crypto.Random.Types
 import Data.Map.Strict
     ( Map )
 import Data.Word
-    ( Word8 )
+    ( Word16 )
 import GHC.Generics
     ( Generic )
 import Internal.Coin
@@ -277,7 +277,7 @@ sumChange = mconcat . change
 --
 newtype CoinSelectionLimit = CoinSelectionLimit
     { calculateLimit
-        :: Word8 -> Word8
+        :: Word16 -> Word16
             -- ^ Calculate the maximum number of inputs allowed for a given
             -- number of outputs.
     } deriving Generic
@@ -343,7 +343,7 @@ data InputsExhaustedError =
 --
 newtype InputLimitExceededError =
     InputLimitExceededError
-    { calculatedInputLimit :: Word8 }
+    { calculatedInputLimit :: Word16 }
     deriving (Eq, Show)
 
 --------------------------------------------------------------------------------

--- a/src/library/Cardano/CoinSelection/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Migration.hs
@@ -65,7 +65,7 @@ import Data.List.NonEmpty
 import Data.Maybe
     ( fromMaybe, mapMaybe )
 import Data.Word
-    ( Word8 )
+    ( Word16 )
 import Internal.Coin
     ( Coin, coinFromIntegral, coinToIntegral )
 
@@ -81,7 +81,7 @@ import qualified Internal.Coin as C
 -- addresses are generated).
 --
 -- It tries to fit as many inputs as possible in a single transaction (fixed by
--- the 'Word8' maximum number of inputs given as argument.
+-- the 'Word16' maximum number of inputs given as argument.
 --
 -- The fee options are used to balance the coin selections and fix a threshold
 -- for dust that is removed from the selections.
@@ -89,7 +89,7 @@ selectCoins
     :: forall i o . (Ord i, Ord o)
     => FeeOptions i o
         -- ^ Fee computation and threshold definition
-    -> Word8
+    -> Word16
         -- ^ Maximum number of inputs we can select per transaction
     -> CoinMap i
         -- ^ UTxO to deplete
@@ -190,14 +190,14 @@ selectCoins feeOpts batchSize utxo =
 
 -- Try to find a fixed "ideal" number of input transactions that would generate
 -- relatively balanced transactions.
-idealBatchSize :: CoinSelectionLimit -> Word8
+idealBatchSize :: CoinSelectionLimit -> Word16
 idealBatchSize coinselOpts = fixPoint 1
   where
-    fixPoint :: Word8 -> Word8
+    fixPoint :: Word16 -> Word16
     fixPoint !n
         | maxN n <= n = n
         | n == maxBound = n
         | otherwise = fixPoint (n + 1)
       where
-        maxN :: Word8 -> Word8
+        maxN :: Word16 -> Word16
         maxN = calculateLimit coinselOpts

--- a/src/test/Cardano/CoinSelection/MigrationSpec.hs
+++ b/src/test/Cardano/CoinSelection/MigrationSpec.hs
@@ -43,7 +43,7 @@ import Data.ByteString
 import Data.Function
     ( (&) )
 import Data.Word
-    ( Word8 )
+    ( Word16 )
 import Internal.Coin
     ( Coin, coinToIntegral )
 import Numeric.Natural
@@ -164,7 +164,7 @@ spec = do
 prop_onlyChangeOutputs
     :: forall i o . (Ord i, Ord o, Show o)
     => FeeOptions i o
-    -> Word8
+    -> Word16
     -> CoinMap i
     -> Property
 prop_onlyChangeOutputs feeOpts batchSize utxo = do
@@ -176,7 +176,7 @@ prop_onlyChangeOutputs feeOpts batchSize utxo = do
 prop_noLessThanThreshold
     :: forall i o . (Ord i, Ord o)
     => FeeOptions i o
-    -> Word8
+    -> Word16
     -> CoinMap i
     -> Property
 prop_noLessThanThreshold feeOpts batchSize utxo = do
@@ -192,7 +192,7 @@ prop_noLessThanThreshold feeOpts batchSize utxo = do
 prop_inputsGreaterThanOutputs
     :: forall i o . (Ord i, Ord o, Show i, Show o)
     => FeeOptions i o
-    -> Word8
+    -> Word16
     -> CoinMap i
     -> Property
 prop_inputsGreaterThanOutputs feeOpts batchSize utxo = do
@@ -208,7 +208,7 @@ prop_inputsGreaterThanOutputs feeOpts batchSize utxo = do
 prop_inputsAreUnique
     :: forall i o . (Ord i, Ord o)
     => FeeOptions i o
-    -> Word8
+    -> Word16
     -> CoinMap i
     -> Property
 prop_inputsAreUnique feeOpts batchSize utxo = do
@@ -222,7 +222,7 @@ prop_inputsAreUnique feeOpts batchSize utxo = do
 prop_inputsStillInUTxO
     :: forall i o . (Ord i, Ord o)
     => FeeOptions i o
-    -> Word8
+    -> Word16
     -> CoinMap i
     -> Property
 prop_inputsStillInUTxO feeOpts batchSize utxo = do
@@ -237,7 +237,7 @@ prop_inputsStillInUTxO feeOpts batchSize utxo = do
 prop_wellBalanced
     :: forall i o . (Ord i, Ord o, Show i, Show o)
     => FeeOptions i o
-    -> Word8
+    -> Word16
     -> CoinMap i
     -> Property
 prop_wellBalanced feeOpts batchSize utxo = do
@@ -280,7 +280,7 @@ instance Arbitrary (Wrapped (Hash "Tx")) where
 -- Generators
 --------------------------------------------------------------------------------
 
-genBatchSize :: Gen Word8
+genBatchSize :: Gen Word16
 genBatchSize = choose (50, 150)
 
 genFeeOptions :: Coin -> Gen (FeeOptions TxIn Address)

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -57,7 +57,7 @@ import Data.Maybe
 import Data.Set
     ( Set )
 import Data.Word
-    ( Word8 )
+    ( Word16, Word8 )
 import Fmt
     ( Buildable (..), blockListF, nameF )
 import Internal.Coin
@@ -299,7 +299,7 @@ instance (Buildable i, Buildable o) => Buildable (CoinSelProp i o) where
 
 -- | A fixture for testing the coin selection
 data CoinSelectionFixture i o = CoinSelectionFixture
-    { maxNumOfInputs :: Word8
+    { maxNumOfInputs :: Word16
         -- ^ Maximum number of inputs that can be selected
     , utxoInputs :: [Integer]
         -- ^ Value (in Lovelace) & number of available coins in the UTxO


### PR DESCRIPTION
## Related Issue

https://github.com/input-output-hk/cardano-coin-selection/pull/55#discussion_r413574687

## Summary

This PR widens the type of `CoinSelectionLimit` to `Word16`.

This is enough for transactions of up to `65535` inputs.

(We could widen the type further, but we'd have to lift the restriction related to `idealBatchSize`. So `Word16` is a sensible compromise for now. See this comment: https://github.com/input-output-hk/cardano-coin-selection/issues/17#issuecomment-618161639)