### PR TITLE
Move `Cardano.Fee` to `Cardano.CoinSelection.Fee`.

### DIFF
--- a/src/library/Cardano/CoinSelection/Algorithm/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Algorithm/Migration.hs
@@ -56,7 +56,7 @@ import Cardano.CoinSelection
     , sumChange
     , sumInputs
     )
-import Cardano.Fee
+import Cardano.CoinSelection.Fee
     ( DustThreshold (..), Fee (..), FeeEstimator (..), FeeOptions (..) )
 import Control.Monad.Trans.State
     ( State, evalState, get, put )

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -18,7 +18,7 @@
 -- Provides functionality for __adjusting__ coin selections in order to pay for
 -- transaction __fees__.
 --
-module Cardano.Fee
+module Cardano.CoinSelection.Fee
     (
       -- * Fundamental Types
       Fee (..)

--- a/src/test/Cardano/CoinSelection/Algorithm/MigrationSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/MigrationSpec.hs
@@ -24,11 +24,11 @@ import Cardano.CoinSelection
     )
 import Cardano.CoinSelection.Algorithm.Migration
     ( idealBatchSize, selectCoins )
-import Cardano.CoinSelectionSpec
-    ()
-import Cardano.Fee
+import Cardano.CoinSelection.Fee
     ( DustThreshold (..), Fee (..), FeeEstimator (..), FeeOptions (..) )
-import Cardano.FeeSpec
+import Cardano.CoinSelection.FeeSpec
+    ()
+import Cardano.CoinSelectionSpec
     ()
 import Cardano.Test.Utilities
     ( Address

--- a/src/test/Cardano/CoinSelection/FeeSpec.hs
+++ b/src/test/Cardano/CoinSelection/FeeSpec.hs
@@ -14,7 +14,7 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Cardano.FeeSpec
+module Cardano.CoinSelection.FeeSpec
     ( spec
     ) where
 
@@ -35,7 +35,7 @@ import Cardano.CoinSelection
     )
 import Cardano.CoinSelection.Algorithm.LargestFirst
     ( largestFirst )
-import Cardano.Fee
+import Cardano.CoinSelection.Fee
     ( DustThreshold (..)
     , Fee (..)
     , FeeAdjustmentError (..)

--- a/src/test/Cardano/Test/Utilities.hs
+++ b/src/test/Cardano/Test/Utilities.hs
@@ -50,7 +50,7 @@ import Prelude
 
 import Cardano.CoinSelection
     ( CoinMap (..), CoinMapEntry (..), CoinSelection (..), coinMapToList )
-import Cardano.Fee
+import Cardano.CoinSelection.Fee
     ( DustThreshold (..), Fee (..) )
 import Control.DeepSeq
     ( NFData (..) )


### PR DESCRIPTION
## Related Issues

#30
https://github.com/input-output-hk/cardano-coin-selection/pull/61#issuecomment-618909468
https://github.com/input-output-hk/cardano-coin-selection/pull/61#issuecomment-618941141 

##

This change ensures that all modules are now within a common namespace `Cardano.CoinSelection` (consistent with the name of the library).

Importantly, the `Fee` module is still at a different level to the coin selection algorithms, which sit within their own namespace `Cardano.CoinSelection.Algorithm`:

```hs
Cardano
└── CoinSelection
    ├── Algorithm 
    │   ├── LargestFirst
    │   ├── Migration
    │   └── RandomImprove
    └── Fee
```