### PR TITLE
Documentation Improvements for `Fee` Module.

### DIFF
--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -198,12 +198,12 @@ data FeeOptions i o = FeeOptions
 --     their value.
 --
 --   - For blockchains that do __not__ allow transactions with /unbalanced/
---     fees, specifying the 'RequirePerfectBalance' policy will always generate
+--     fees, specifying the 'RequireBalancedFee' policy will always generate
 --     selections with fees that are perfectly-balanced, even if the resulting
 --     fees are higher than could be achieved by allowing unbalanced fees.
 --
 data FeeBalancingPolicy
-    = RequirePerfectBalance
+    = RequireBalancedFee
         -- ^ Generate selections that are perfectly balanced, with the
         -- trade-off of allowing slightly higher fees.
     | RequireMinimalFee
@@ -473,7 +473,7 @@ reduceChangeOutputs opts s = do
                     case feeBalancingPolicy opts of
                         RequireMinimalFee ->
                             pure (s, Fee C.zero)
-                        RequirePerfectBalance ->
+                        RequireBalancedFee ->
                             pure (sDangling, Fee remainder)
 
                 -- If however, adding the dangling change doesn't cost more than

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -98,10 +98,20 @@ newtype Fee = Fee { unFee :: Coin }
     deriving stock (Eq, Generic, Ord)
     deriving Show via (Quiet Fee)
 
--- | Defines the maximum size of a dust coin.
+-- | Defines the /maximum/ size of a __dust coin__.
 --
--- Change values that are less than or equal to this threshold will not be
--- included in coin selections produced by the 'adjustForFee' function.
+-- Functions that accept a 'DustThreshold' argument will generally not include
+-- values that are /less than or equal to/ this threshold in the 'change' sets
+-- of generated selections, /coalescing/ such coins together into larger
+-- coins that /exceed/ the threshold.
+--
+-- Specifying a dust threshold of __/n/__ causes all coins that are less than
+-- or equal to __/n/__ to be treated as dust and coalesced together.
+--
+-- Specifying a dust threshold of __0__ completely /disables/ dust elimination
+-- with the exception of zero-valued coins, which will always be eliminated.
+--
+-- See 'coalesceDust'.
 --
 newtype DustThreshold = DustThreshold { unDustThreshold :: Coin }
     deriving stock (Eq, Generic, Ord)
@@ -130,14 +140,9 @@ data FeeOptions i o = FeeOptions
 
     , dustThreshold
         :: DustThreshold
-        -- ^ Change addresses below the given threshold will be evicted
-        -- from the created transaction. This can be useful if you do not want
-        -- to produce change output below a certain threshold and instead,
-        -- conflate them with other change outputs.
-        --
-        -- Setting the 'dustThreshold' to @mempty@ is a very reasonable choice
-        -- if you don't know what to do with this. This would have no effect and
-        -- keep all valid coin values that are positive.
+        -- ^ The threshold to use for dust elimination. Specifying a threshold
+        -- of zero will disable dust elimination. See 'DustThreshold' for more
+        -- details.
 
     , feeBalancingPolicy
         :: FeeBalancingPolicy

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -279,7 +279,10 @@ senderPaysFee opts utxo sel =
   where
     go
         :: CoinSelection i o
-        -> StateT (CoinMap i) (ExceptT (FeeAdjustmentError i o) m) (CoinSelection i o)
+        -> StateT
+            (CoinMap i)
+            (ExceptT (FeeAdjustmentError i o) m)
+            (CoinSelection i o)
     go coinSel@(CoinSelection inps outs chgs) = do
         -- Substract fee from change outputs, proportionally to their value.
         (coinSel', remFee) <- lift $ except $ reduceChangeOutputs opts coinSel
@@ -409,10 +412,10 @@ reduceChangeOutputs opts s = do
                 -- we've left too much, but adding a change output would be more
                 -- expensive than not having it. Here we have two choices:
                 --
-                -- a) If the node allows unbalanced transaction, we can stop here
-                --    and do nothing. We'll leave slightly more than what's needed
-                --    for fees, but having an extra change output isn't worth it
-                --    anyway.
+                -- a) If the node allows unbalanced transaction, we can stop
+                --    here and do nothing. We'll leave slightly more than what's
+                --    needed for fees, but having an extra change output isn't
+                --    worth it anyway.
                 --
                 -- b) If we __must__ balance the transaction, then we can choose
                 --    to pay the extra cost by adding the change output and

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -225,7 +225,7 @@ data FeeAdjustmentError i o
     | CoinSelectionUnderfunded (CoinSelection i o)
     -- ^ Indicates that the given coin selection is __underfunded__: the total
     -- value of 'inputs' is less than the total value of 'outputs', as
-    -- calculated by the 'coinMapValue' function.
+    -- calculated by the 'CoinSelection.coinMapValue' function.
     deriving (Show, Eq)
 
 -- | Adjusts the given 'CoinSelection' in order to pay for a __transaction__

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -175,7 +175,7 @@ data FeeAdjustmentError i o
     -- __/f/__ and the total value __/s/__ of currently-selected inputs.
 
     | CoinSelectionUnderfunded (CoinSelection i o)
-    -- ^ Indicates that given the coin selection is __underfunded__: the total
+    -- ^ Indicates that the given coin selection is __underfunded__: the total
     -- value of 'inputs' is less than the total value of 'outputs', as
     -- calculated by the 'coinMapValue' function.
     deriving (Show, Eq)

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -100,9 +100,9 @@ newtype Fee = Fee { unFee :: Coin }
 
 -- | Defines the /maximum/ size of a __dust coin__.
 --
--- Functions that accept a 'DustThreshold' argument will generally not include
--- values that are /less than or equal to/ this threshold in the 'change' sets
--- of generated selections, /coalescing/ such coins together into larger
+-- Functions that accept a 'DustThreshold' argument will generally exclude
+-- values that are /less than or equal to/ this threshold from the 'change'
+-- sets of generated selections, /coalescing/ such coins together into larger
 -- coins that /exceed/ the threshold.
 --
 -- Specifying a dust threshold of __/n/__ causes all coins that are less than

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -284,10 +284,21 @@ data FeeAdjustmentError i o
 -- Since adjusting a selection can affect the fee estimate produced by
 -- 'estimateFee', the process of adjustment is an /iterative/ process.
 --
--- This function terminates when it has generated a 'CoinSelection' that
--- satisfies the following property:
+-- The termination post-condition depends on the choice of
+-- 'FeeBalancingPolicy':
 --
--- >>> sumInputs c ≈ sumOutputs c + sumChange c + estimateFee c
+--   - If 'RequireBalancedFee' is specified, this function terminates
+--     only when it has generated a 'CoinSelection' __'s'__ that satisfies the
+--     following property:
+--
+--         >>> sumInputs s = sumOutputs s + sumChange s + estimateFee s
+--
+--   - If 'RequireMinimalFee' policy is specified, the above /equality/
+--     is relaxed to the following /inequality/:
+--
+--         >>> sumInputs s ≥ sumOutputs s + sumChange s + estimateFee s
+--
+-- See 'FeeBalancingPolicy' for more details.
 --
 adjustForFee
     :: (Ord i, MonadRandom m)

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -394,17 +394,17 @@ reduceChangeOutputs opts s = do
         -- The outcome depends on whether or not the node allows transactions
         -- to be unbalanced.
         Just δ_original | δ_original > φ_original -> do
-            let extraChng = δ_original `C.distance` φ_original
-            let sDangling = s { change = splitCoin extraChng (change s) }
+            let extraChg = δ_original `C.distance` φ_original
+            let sDangling = s { change = splitCoin extraChg (change s) }
             let Fee φ_dangling = estimateFee (feeEstimator opts) sDangling
             -- We have `δ_dangling = φ_original` by construction of sDangling.
             --
             -- Proof:
             --
             -- δ_dangling = Σi_dangling - (Σo_dangling + Σc_dangling)
-            --            = Σi_original - (Σo_original + Σc_original + extraChng)
-            --            = Σi_original - (Σo_original + Σc_original) - extraChng
-            --            = δ_original - extraChng
+            --            = Σi_original - (Σo_original + Σc_original + extraChg)
+            --            = Σi_original - (Σo_original + Σc_original) - extraChg
+            --            = δ_original - extraChg
             --            = δ_original - (δ_original - φ_original)
             --            = φ_original
             let δ_dangling = φ_original

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -238,17 +238,17 @@ data FeeAdjustmentError i o
 -- produce coin selections that are /exactly balanced/, satisfying the
 -- following equality:
 --
--- >>> sumInputs c = sumOutputs c + sumChange c
+-- >>> sumInputs s = sumOutputs s + sumChange s
 --
 -- In order to pay for a transaction fee, the above equality must be
 -- transformed into an /inequality/:
 --
--- >>> sumInputs c > sumOutputs c + sumChange c
+-- >>> sumInputs s > sumOutputs s + sumChange s
 --
 -- The difference between these two sides represents value to be paid /by the/
 -- /originator/ of the transaction, in the form of a fee:
 --
--- >>> sumInputs c = sumOutputs c + sumChange c + fee
+-- >>> sumInputs s = sumOutputs s + sumChange s + fee
 --
 -- == The Adjustment Process
 --

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -204,11 +204,11 @@ data FeeOptions i o = FeeOptions
 --
 data FeeBalancingPolicy
     = RequireBalancedFee
-        -- ^ Generate selections that are perfectly balanced, with the
+        -- ^ Generate selections with fees that are perfectly balanced, with the
         -- trade-off of allowing slightly higher fees.
     | RequireMinimalFee
         -- ^ Generate selections with the lowest fees possible, with the
-        -- trade-off of allowing slightly imbalanced selections.
+        -- trade-off of allowing slightly imbalanced fees.
     deriving (Generic, Show, Eq)
 
 -- | Represents the set of possible failures that can occur when adjusting a

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -117,11 +117,22 @@ newtype DustThreshold = DustThreshold { unDustThreshold :: Coin }
     deriving stock (Eq, Generic, Ord)
     deriving Show via (Quiet DustThreshold)
 
--- | Provides a function capable of estimating the fee for a given coin
---   selection.
+-- | Provides a function capable of __estimating__ the transaction fee required
+--   for a given coin selection, according to the rules of a particular
+--   blockchain.
 --
--- The fee estimate can depend on the numbers of inputs, outputs, and change
--- outputs within the coin selection, as well as their magnitudes.
+-- The fee estimate should be a function of the __current__ memberships of the
+-- 'inputs', 'outputs', and 'change' sets.
+--
+-- Depending on the rules of the blockchain under consideration, the fee
+-- estimate may take either (or both) of the following factors into account:
+--
+--   - the number of entries in each set;
+--   - the coin value of each set member.
+--
+-- A fee estimate may differ from the final fee required for a selection, as
+-- fees are generally paid for by /adjusting/ a given selection to make a /new/
+-- selection. See 'adjustForFee' for more details of this process.
 --
 newtype FeeEstimator i o = FeeEstimator
     { estimateFee :: CoinSelection i o -> Fee

--- a/src/test/Cardano/CoinSelection/Algorithm/MigrationSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/MigrationSpec.hs
@@ -148,7 +148,7 @@ spec = do
                     , feeEstimator = FeeEstimator $ \s -> unsafeFee @Int
                         $ fromIntegral
                         $ 5 * (length (inputs s) + length (outputs s))
-                    , feeBalancingPolicy = RequirePerfectBalance
+                    , feeBalancingPolicy = RequireBalancedFee
                     }
             let batchSize = 1
             let utxo = CoinMap $ Map.fromList
@@ -250,7 +250,7 @@ prop_wellBalanced feeParams batchSize utxo = do
     let feeOpts = FeeOptions
             { dustThreshold = DustThreshold mempty
             , feeEstimator = stableEstimator feeParams
-            , feeBalancingPolicy = RequirePerfectBalance
+            , feeBalancingPolicy = RequireBalancedFee
             }
     let selections = selectCoins feeOpts batchSize utxo
     conjoin
@@ -303,7 +303,7 @@ genFeeOptions dust = do
             in unsafeFee $
                   (C.coinToIntegral dust `div` 100) * x + C.coinToIntegral dust
         , dustThreshold = DustThreshold dust
-        , feeBalancingPolicy = RequirePerfectBalance
+        , feeBalancingPolicy = RequireBalancedFee
         }
 
 -- | Generate a given UTxO with a particular percentage of dust

--- a/src/test/Cardano/CoinSelection/FeeSpec.hs
+++ b/src/test/Cardano/CoinSelection/FeeSpec.hs
@@ -738,13 +738,13 @@ propReduceChangeOutputsConverge sel opts = do
     let prop = case feeBalancingPolicy opts of
             -- If fees are null and we require balanced selections, then the
             -- selection must be exactly balanced.
-            RequirePerfectBalance | remainder == Fee C.zero ->
+            RequireBalancedFee | remainder == Fee C.zero ->
                 (Fee <$> delta sel') == Just fee
 
             -- Otherwise, either the change outputs are null, or the delta is
             -- positive because of the dangling output and we'll have to pay for
             -- it.
-            RequirePerfectBalance ->
+            RequireBalancedFee ->
                 null (change sel') || (delta sel' >= Just C.zero)
 
             -- If fees are null and we do not require balanced selections, then
@@ -853,7 +853,7 @@ feeOptions fee dust = FeeOptions
     , dustThreshold =
         unsafeDustThreshold dust
     , feeBalancingPolicy =
-        RequirePerfectBalance
+        RequireBalancedFee
     }
 
 feeUnitTest
@@ -1090,7 +1090,7 @@ instance Arbitrary (FeeOptions i o) where
             [ stableEstimator <$> arbitrary
             , valueDependentEstimator <$> arbitrary
             ]
-        feeBalancingPolicy <- elements [RequirePerfectBalance, RequireMinimalFee]
+        feeBalancingPolicy <- elements [RequireBalancedFee, RequireMinimalFee]
         return $ FeeOptions {dustThreshold, feeEstimator, feeBalancingPolicy}
 
 instance Arbitrary a => Arbitrary (NonEmpty a) where


### PR DESCRIPTION
## Related Issue

#18 

## Summary

This PR makes a selection of improvements to the documentation of the `Fee` module:

- [x] Reconciles the various descriptions of dust thresholds, so that there is a single main description, with links to that description from other places in the documentation.
- [x] Extends the explanation for `FeeEstimator` so that:
    - [x] it's clear what is required by implementers of `estimateFee`;
    - [x] it's clear why the result is an _estimate_, rather than a final fee value. 
- [x] Clarifies the explanation for `FeeBalancingPolicy`, so that:
    - [x] the definitions of _balanced_ and _unbalanced_ are clearly stated in terms of properties.
- [x] Corrects a small mistake in the description for `CoinSelectionUnderfunded`.
- [x] Corrects a few broken documentation links (to identifiers that are not directly imported).