### PR TITLE
Simplify comment for `feeBalancingPolicy` field.

### DIFF
--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -161,8 +161,7 @@ data FeeOptions i o = FeeOptions
 
     , feeBalancingPolicy
         :: FeeBalancingPolicy
-        -- ^ What do to when we encounter a dangling change output.
-        -- See 'FeeBalancingPolicy'
+        -- ^ Which fee balancing policy to use.
     } deriving Generic
 
 -- | A choice of fee balancing policies for use when adjusting a coin selection.


### PR DESCRIPTION
## Related PR

#18 

## Summary

This tiny PR makes the field description for `feeBalancingPolicy` consistent with the documentation for the `FeeBalancingPolicy` type.

If a user reading the documentation for `FeeOptions` needs to understand more about which `FeeBalancingPolicy` to use, it's easy to follow the link to the `FeeBalancingPolicy` type documentation, which gives a comprehensive explanation.