### PR TITLE
Fix github workflow: coverage and documentation export

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,6 @@ jobs:
     - name: 🏷️ Variables
       id: variables
       run: |
-        stack setup
         echo ::set-output name=pkg_name::$(cat *.cabal | grep "name:" | sed "s/name:\s*\(.*\)/\1/")
 
     - name: 📸 Build Snapshot
@@ -48,26 +47,14 @@ jobs:
       run: |
         stack --no-terminal test --bench --only-snapshot
 
-    - name: ✍  Check hlint and stylish
-      run: |
-        curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
-        curl -sSL https://raw.github.com/jaspervdj/stylish-haskell/master/scripts/latest.sh | sh -s $(find . -type f -name "*.hs" ! -path "*.stack-work*") -i
-        if [ -z "$(git status --porcelain)" ]; then
-            echo "No style errors detected."
-        else
-            echo "Style errors detected:"
-            git diff
-            exit 1
-        fi
-
     - name: 🔨 Build & Test
       run: |
-        stack --no-terminal test --bench --no-run-benchmarks --haddock --no-haddock-deps --coverage --flag $PKG_NAME:release
+        stack --no-terminal test --bench --haddock --no-haddock-deps --no-run-benchmarks --flag $PKG_NAME:release
+        mkdir -p dist/haddock && mv $(stack path --local-install-root)/doc/* dist/haddock
+        sed -i 's@href="[^"]*/doc/\([^"]*.html\)"@href="\1"@g' dist/haddock/index.html
         wget -O Makefile https://raw.githubusercontent.com/input-output-hk/adrestia/master/.haskell/coverage/Makefile
         mkdir -p .coverage && touch .coverage/template.overlay
-        DESTDIR=dist/coverage make report  && DESTDIR=dist/coverage make badge
-        mkdir -p dist/haddock && mv $(stack path --local-install-root)/doc/* dist/haddock
-        sed -i 's@href="[^"]*/doc/\([^"]*.html\)"@href="\1"@' dist/haddock/index.html
+        DESTDIR=dist/coverage make report && DESTDIR=dist/coverage make badge
       env:
         PKG_NAME: ${{ steps.variables.outputs.pkg_name }}
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,31 @@
+name: Coding Standards
+
+on:
+  pull_request:
+    branches: [ "master" ]
+  push:
+    branches: [ "master" ]
+    tags: [ "*.*.*" ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v1
+
+    - name: ✍  Check hlint and stylish
+      run: |
+        curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
+        curl -sSL https://raw.github.com/jaspervdj/stylish-haskell/master/scripts/latest.sh | sh -s $(find . -type f -name "*.hs" ! -path "*.stack-work*") -i
+        if [ -z "$(git status --porcelain)" ]; then
+            echo "No style errors detected."
+        else
+            echo "Style errors detected:"
+            git diff
+            exit 1
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ cabal.project.local~
 .ghci
 *.tix
 stack.yaml.lock
-*.cabal
 
 ### Nix ###
 result*

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 <a href="https://hackage.haskell.org/package/cardano-coin-selection"><img src="https://img.shields.io/hackage/v/cardano-coin-selection?style=for-the-badge" /></a>
 <a href="https://github.com/input-output-hk/cardano-coin-selection/releases"><img src="https://img.shields.io/github/v/release/input-output-hk/cardano-coin-selection?color=%239b59b6&label=RELEASE&sort=semver&style=for-the-badge"/></a>
-<a href="https://github.com/input-output-hk/cardano-coin-selection/actions?query=workflow%3ATest"><img src="https://img.shields.io/github/workflow/status/input-output-hk/cardano-coin-selection/Test?style=for-the-badge" /></a>
+<a href='https://github.com/input-output-hk/cardano-coin-selection/actions?query=workflow%3A"Continuous+Integration"'><img src="https://img.shields.io/github/workflow/status/input-output-hk/cardano-coin-selection/Continuous Integration?style=for-the-badge" /></a>
+  <a href="https://input-output-hk.github.io/cardano-coin-selection/coverage/hpc_index.html"><img src="https://input-output-hk.github.io/cardano-coin-selection/coverage/badge.svg" /></a>
 
-## Cardano Coin Selection
+## Overview
 
 This repository provides a [Haskell](https://www.haskell.org/) library of
 algorithms for coin selection and fee balancing.
+
+## Documentation
+
+API documentation is available [here](https://input-output-hk.github.io/cardano-coin-selection/haddock).
+
 
 ## Contributing
 
@@ -16,4 +22,4 @@ When creating a pull request, please make sure that your code adheres to our
 
 <hr />
 
-<a href="https://github.com/input-output-hk/cardano-coin-selection/blob/master/LICENSE"><img src="https://img.shields.io/github/license/input-output-hk/cardano-wallet.svg?style=for-the-badge" /></a>
+<a href="https://github.com/input-output-hk/cardano-coin-selection/blob/master/LICENSE"><img src="https://img.shields.io/github/license/input-output-hk/cardano-coin-selection.svg?style=for-the-badge" /></a>

--- a/cardano-coin-selection.cabal
+++ b/cardano-coin-selection.cabal
@@ -1,0 +1,103 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: fa91aa04303b2016d424d05014b688d5845de29176adad56b44a698e849d080a
+
+name:           cardano-coin-selection
+version:        1.0.0
+synopsis:       Algorithms for coin selection and fee balancing.
+description:    Please see the README on GitHub at <https://github.com/input-output-hk/cardano-coin-selection>
+category:       Cardano
+homepage:       https://github.com/input-output-hk/cardano-coin-selection#readme
+bug-reports:    https://github.com/input-output-hk/cardano-coin-selection/issues
+author:         IOHK
+maintainer:     operations@iohk.io
+copyright:      2020 IOHK
+license:        Apache-2.0
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/input-output-hk/cardano-coin-selection
+
+flag release
+  description: Compile executables for a release.
+  manual: True
+  default: False
+
+library
+  exposed-modules:
+      Cardano.CoinSelection
+      Cardano.CoinSelection.Algorithm
+      Cardano.CoinSelection.Algorithm.LargestFirst
+      Cardano.CoinSelection.Algorithm.Migration
+      Cardano.CoinSelection.Algorithm.RandomImprove
+      Cardano.CoinSelection.Fee
+      Internal
+      Internal.Coin
+      Internal.Invariant
+      Internal.Rounding
+  other-modules:
+      Paths_cardano_coin_selection
+  hs-source-dirs:
+      src/library
+      src/internal
+  default-extensions: NoImplicitPrelude
+  ghc-options: -Wall -Wcompat -fwarn-redundant-constraints
+  build-depends:
+      base >=4.7 && <5
+    , bytestring
+    , containers
+    , cryptonite
+    , deepseq
+    , quiet
+    , text
+    , transformers
+  if flag(release)
+    ghc-options: -Werror
+  default-language: Haskell2010
+
+test-suite unit
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Cardano.CoinSelection.Algorithm.LargestFirstSpec
+      Cardano.CoinSelection.Algorithm.MigrationSpec
+      Cardano.CoinSelection.Algorithm.RandomImproveSpec
+      Cardano.CoinSelection.FeeSpec
+      Cardano.CoinSelection.TypesSpec
+      Cardano.CoinSelectionSpec
+      Cardano.Test.Utilities
+      Internal.CoinSpec
+      Test.Vector.Shuffle
+      Test.Vector.ShuffleSpec
+      Paths_cardano_coin_selection
+  hs-source-dirs:
+      src/test
+  default-extensions: NoImplicitPrelude
+  ghc-options: -Wall -Wcompat -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      QuickCheck
+    , base >=4.7 && <5
+    , bytestring
+    , cardano-coin-selection
+    , containers
+    , cryptonite
+    , deepseq
+    , fmt
+    , hspec
+    , memory
+    , quiet
+    , random
+    , text
+    , transformers
+    , vector
+  if flag(release)
+    ghc-options: -Werror
+  default-language: Haskell2010


### PR DESCRIPTION
Fixes #60 #68 

- 96378ea3c2fd3fb9c8a940a77b282683a829139b
  :round_pushpin: **repair coverage and documentation export in github workflow**
  The 'sed' expression replacing absolute references to relative references needed to be applied with the 'g' flag
to replace all matching occurences, and not only the first one.

And, the release flag was conflicting with the coverage builds.

- 2cd8f64e89223c7b5588533f3cdd683ef973c025
  :round_pushpin: **re-add coverage badge and documentation to README**
