### PR TITLE
Add lower version bound for `transformers` dependency.

### DIFF
--- a/cardano-coin-selection.cabal
+++ b/cardano-coin-selection.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fa91aa04303b2016d424d05014b688d5845de29176adad56b44a698e849d080a
+-- hash: a18cf9486584a8610bc4358e634b9e6e98745f70162228e8f1ae2478b2d0a783
 
 name:           cardano-coin-selection
 version:        1.0.0
@@ -58,7 +58,7 @@ library
     , deepseq
     , quiet
     , text
-    , transformers
+    , transformers >=0.5.6.0
   if flag(release)
     ghc-options: -Werror
   default-language: Haskell2010
@@ -96,7 +96,7 @@ test-suite unit
     , quiet
     , random
     , text
-    , transformers
+    , transformers >=0.5.6.0
     , vector
   if flag(release)
     ghc-options: -Werror

--- a/package.yaml
+++ b/package.yaml
@@ -44,7 +44,7 @@ library:
   - deepseq
   - quiet
   - text
-  - transformers
+  - transformers >= 0.5.6.0
 
 tests:
   unit:
@@ -76,5 +76,5 @@ tests:
     - quiet
     - random
     - text
-    - transformers
+    - transformers >= 0.5.6.0
     - vector


### PR DESCRIPTION
## Related Issue

#71 

## Summary

This PR adds a version bound of `>= 0.5.6.0` for the `transformers` package.

Attempting to build with earlier versions of `transformers` causes the following failure:

```hs
src/library/Cardano/CoinSelection/Fee.hs:351:31: error:                             
    • Couldn't match type ‘m’ with ‘Data.Functor.Identity.Identity’                 
      ‘m’ is a rigid type variable bound by                   
        the type signature for:                               
          senderPaysFee :: forall i o (m :: * -> *).          
                           (Ord i, MonadRandom m) =>          
                           FeeOptions i o                     
                           -> CoinMap i                                                                                                            
                           -> CoinSelection i o                                             
                           -> ExceptT (FeeAdjustmentError i o) m (CoinSelection i o)
        at src/library/Cardano/CoinSelection/Fee.hs:(334,1)-(339,61)
      Expected type: StateT                                                 
                       (CoinMap i)                         
                       (ExceptT (FeeAdjustmentError i o) m)
                       (CoinSelection i o, Fee)
        Actual type: StateT
                       (CoinMap i)
                       (ExceptT (FeeAdjustmentError i o) Data.Functor.Identity.Identity)
                       (CoinSelection i o, Fee)
```