### PR TITLE
Make the `Largest-First` algorithm pay for outputs collectively.

### DIFF
--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -233,7 +233,7 @@ data CoinSelectionResult i o = CoinSelectionResult
         -- ^ The generated coin selection.
     , inputsRemaining :: CoinMap i
         -- ^ The set of inputs that were __not__ selected.
-    }
+    } deriving (Eq, Show)
 
 -- | A __coin selection__ is the basis for a /transaction/.
 --

--- a/src/library/Cardano/CoinSelection/Algorithm/LargestFirst.hs
+++ b/src/library/Cardano/CoinSelection/Algorithm/LargestFirst.hs
@@ -46,107 +46,22 @@ import qualified Internal.Coin as C
 
 -- | An implementation of the __Largest-First__ coin selection algorithm.
 --
--- = Overview
+-- The Largest-First coin selection algorithm considers available inputs in
+-- /descending/ order of value, from /largest/ to /smallest/.
 --
--- The __Largest-First__ algorithm processes outputs in /descending order of/
--- /value/, from /largest/ to /smallest/.
+-- When applied to a set of requested outputs, the algorithm repeatedly selects
+-- entries from the available inputs set until the total value of selected
+-- entries is greater than or equal to the total value of requested outputs.
 --
--- For each output, it repeatedly selects the /largest/ remaining unspent UTxO
--- entry until the value of selected entries is greater than or equal to the
--- value of that output.
+-- === Change Values
 --
--- = State Maintained by the Algorithm
+-- If the total value of selected inputs is /greater than/ the total value of
+-- all requested outputs, the 'change' set of the resulting selection will
+-- contain /a single coin/ with the excess value.
 --
--- At all stages of processing, the algorithm maintains:
---
---  1.  A __/remaining UTxO list/__
---
---      This is initially equal to the given /initial UTxO set/ parameter,
---      sorted into /descending order of coin value/.
---
---      The /head/ of the list is always the remaining UTxO entry with the
---      /largest coin value/.
---
---      Entries are incrementally removed from the /head/ of the list as the
---      algorithm proceeds, until the list is empty.
---
---  2.  An __/unpaid output list/__
---
---      This is initially equal to the given /output list/ parameter, sorted
---      into /descending order of coin value/.
---
---      The /head/ of the list is always the unpaid output with the
---      /largest coin value/.
---
---      Entries are incrementally removed from the /head/ of the list as the
---      algorithm proceeds, until the list is empty.
---
---  3.  An __/accumulated coin selection/__
---
---      This is initially /empty/.
---
---      Entries are incrementally added as each output is paid for, until the
---      /unpaid output list/ is empty.
---
--- = Cardinality Rules
---
--- The algorithm requires that:
---
---  1.  Each output from the given /output list/ is paid for by /one or more/
---      entries from the /initial UTxO set/.
---
---  2.  Each entry from the /initial UTxO set/ is used to pay for /at most one/
---      output from the given /output list/.
---
---      (A single UTxO entry __cannot__ be used to pay for multiple outputs.)
---
--- = Order of Processing
---
--- The algorithm proceeds according to the following sequence of steps:
---
---  *   /Step 1/
---
---      Remove a single /unpaid output/ from the head of the
---      /unpaid output list/.
---
---  *   /Step 2/
---
---      Repeatedly remove UTxO entries from the head of the
---      /remaining UTxO list/ until the total value of entries removed is
---      /greater than or equal to/ the value of the /removed output/.
---
---  *   /Step 3/
---
---      Use the /removed UTxO entries/ to pay for the /removed output/.
---
---      This is achieved by:
---
---      *  adding the /removed UTxO entries/ to the 'inputs' field of the
---         /accumulated coin selection/.
---      *  adding the /removed output/ to the 'outputs' field of the
---         /accumulated coin selection/.
---
---  *   /Step 4/
---
---      If the /total value/ of the /removed UTxO entries/ is greater than the
---      value of the /removed output/, generate a coin whose value is equal to
---      the exact difference, and add it to the 'change' field of the
---      /accumulated coin selection/.
---
---  *   /Step 5/
---
---      If the /unpaid output list/ is empty, __terminate__ here.
---
---      Otherwise, return to /Step 1/.
---
--- = Termination
---
--- The algorithm terminates __successfully__ if the /remaining UTxO list/ is
--- not depleted before the /unpaid output list/ can be fully depleted (i.e., if
--- all the outputs have been paid for).
---
--- The /accumulated coin selection/ and /remaining UTxO list/ are returned to
--- the caller.
+-- If the total value of selected inputs is /exactly equal to/ the total value
+-- of all requested outputs, the 'change' set of the resulting selection will
+-- be /empty/.
 --
 -- === Failure Modes
 --

--- a/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
@@ -27,7 +27,7 @@ import Cardano.CoinSelection
 import Cardano.CoinSelection.Algorithm.LargestFirst
     ( largestFirst )
 import Cardano.CoinSelectionSpec
-    ( CoinSelProp (..)
+    ( CoinSelectionData (..)
     , CoinSelectionFixture (..)
     , CoinSelectionTestResult (..)
     , coinSelectionUnitTest
@@ -214,9 +214,9 @@ spec = do
 
 propInputDecreasingOrder
     :: Ord i
-    => CoinSelProp i o
+    => CoinSelectionData i o
     -> Property
-propInputDecreasingOrder (CoinSelProp utxo txOuts) =
+propInputDecreasingOrder (CoinSelectionData utxo txOuts) =
     isRight selection ==>
         let Right (CoinSelectionResult s _) = selection in
         prop s

--- a/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
@@ -205,9 +205,6 @@ spec = do
 
     describe "Coin selection: largest-first algorithm: properties" $ do
 
-        it "forall (UTxO, NonEmpty TxOut), there's at least as many selected \
-            \inputs as there are requested outputs"
-            (property $ propAtLeast @TxIn @Address)
         it "forall (UTxO, NonEmpty TxOut), for all selected input, there's no \
             \bigger input in the UTxO that is not already in the selected \
             \inputs"
@@ -216,21 +213,6 @@ spec = do
 --------------------------------------------------------------------------------
 -- Properties
 --------------------------------------------------------------------------------
-
-propAtLeast
-    :: Ord i
-    => CoinSelProp i o
-    -> Property
-propAtLeast (CoinSelProp utxo txOuts) =
-    isRight selection ==>
-        let Right (CoinSelectionResult s _) = selection in
-        prop s
-  where
-    prop (CoinSelection inps _ _) =
-        length inps `shouldSatisfy` (>= length txOuts)
-    selection = runIdentity $ runExceptT $ selectCoins largestFirst
-        $ CoinSelectionParameters utxo txOuts selectionLimit
-    selectionLimit = CoinSelectionLimit $ const 100
 
 propInputDecreasingOrder
     :: Ord i

--- a/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
@@ -209,7 +209,7 @@ spec = do
 --------------------------------------------------------------------------------
 
 propAtLeast
-    :: (Ord i, Ord o)
+    :: Ord i
     => CoinSelProp i o
     -> Property
 propAtLeast (CoinSelProp utxo txOuts) =
@@ -224,7 +224,7 @@ propAtLeast (CoinSelProp utxo txOuts) =
     selectionLimit = CoinSelectionLimit $ const 100
 
 propInputDecreasingOrder
-    :: (Ord i, Ord o)
+    :: Ord i
     => CoinSelProp i o
     -> Property
 propInputDecreasingOrder (CoinSelProp utxo txOuts) =

--- a/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
@@ -179,6 +179,58 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
+            "Expect success: fewer inputs than outputs: case #1"
+            (Right $ CoinSelectionTestResult
+                { rsInputs = [100]
+                , rsOutputs = [1,2,3,4]
+                , rsChange = [90]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 1000
+                , utxoInputs = [100,100]
+                , txOutputs = [1,2,3,4]
+                })
+
+        coinSelectionUnitTest largestFirst
+            "Expect success: fewer inputs than outputs: case #2"
+            (Right $ CoinSelectionTestResult
+                { rsInputs = [100]
+                , rsOutputs = [1,2,3,4]
+                , rsChange = [90]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 1000
+                , utxoInputs = [100,10]
+                , txOutputs = [1,2,3,4]
+                })
+
+        coinSelectionUnitTest largestFirst
+            "Expect success: fewer inputs than outputs: case #3"
+            (Right $ CoinSelectionTestResult
+                { rsInputs = [10]
+                , rsOutputs = [1,2,3,4]
+                , rsChange = []
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 1000
+                , utxoInputs = [10,10]
+                , txOutputs = [1,2,3,4]
+                })
+
+        coinSelectionUnitTest largestFirst
+            "Expect success: fewer inputs than outputs: case #4"
+            (Right $ CoinSelectionTestResult
+                { rsInputs = [100]
+                , rsOutputs = replicate 100 1
+                , rsChange = []
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 1
+                , utxoInputs = [100]
+                , txOutputs = replicate 100 1
+                })
+
+        coinSelectionUnitTest largestFirst
             "UTxO balance not sufficient: case #1"
             (Left $ InputValueInsufficient $ InputValueInsufficientError
                 (unsafeCoin @Int 39) (unsafeCoin @Int 40))

--- a/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
@@ -18,10 +18,8 @@ import Cardano.CoinSelection
     , CoinSelectionLimit (..)
     , CoinSelectionParameters (..)
     , CoinSelectionResult (..)
-    , InputCountInsufficientError (..)
     , InputLimitExceededError (..)
     , InputValueInsufficientError (..)
-    , InputsExhaustedError (..)
     , coinMapToList
     )
 import Cardano.CoinSelection.Algorithm.LargestFirst
@@ -105,8 +103,8 @@ spec = do
 
         coinSelectionUnitTest largestFirst ""
             (Right $ CoinSelectionTestResult
-                { rsInputs = [6,10,5]
-                , rsChange = [5,4]
+                { rsInputs = [6,10]
+                , rsChange = [4]
                 , rsOutputs = [11,1]
                 })
             (CoinSelectionFixture
@@ -126,7 +124,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "UTxO balance not sufficient, and not fragmented enough"
+            "UTxO balance not sufficient"
             (Left $ InputValueInsufficient $ InputValueInsufficientError
                 (unsafeCoin @Int 39) (unsafeCoin @Int 43))
             (CoinSelectionFixture
@@ -136,8 +134,12 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient, but not fragmented enough"
-            (Left $ InputCountInsufficient $ InputCountInsufficientError 3 4)
+            "UTxO balance sufficient"
+            (Right $ CoinSelectionTestResult
+                { rsInputs = [12,17,20]
+                , rsChange = [6]
+                , rsOutputs = [1,1,1,40]
+                })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , utxoInputs = [12,20,17]
@@ -145,9 +147,12 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient, fragmented enough, but single output \
-            \depletes all UTxO entries"
-            (Left (InputsExhausted InputsExhaustedError))
+            "UTxO balance sufficient"
+            (Right $ CoinSelectionTestResult
+                { rsInputs = [12,17,20]
+                , rsChange = [8]
+                , rsOutputs = [1,40]
+                })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , utxoInputs = [12,20,17]
@@ -155,9 +160,12 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient, fragmented enough, but single output \
-            \depletes all UTxO entries"
-            (Left (InputsExhausted InputsExhaustedError))
+            "UTxO balance sufficient"
+            (Right $ CoinSelectionTestResult
+                { rsInputs = [10,20,20]
+                , rsChange = [3]
+                , rsOutputs = [6,41]
+                })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , utxoInputs = [20,20,10,5]
@@ -165,8 +173,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient, fragmented enough, but maximum input \
-            \count exceeded"
+            "UTxO balance sufficient, but maximum input count exceeded"
             (Left $ InputLimitExceeded $ InputLimitExceededError 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
@@ -175,8 +182,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient, fragmented enough, but maximum input \
-            \count exceeded"
+            "UTxO balance sufficient, but maximum input count exceeded"
             (Left $ InputLimitExceeded $ InputLimitExceededError 9)
             (CoinSelectionFixture
                 { maxNumOfInputs = 9
@@ -185,9 +191,12 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient, fragmented enough, but maximum input \
-            \count exceeded"
-            (Left $ InputLimitExceeded $ InputLimitExceededError 2)
+            "UTxO balance sufficient"
+            (Right $ CoinSelectionTestResult
+                { rsInputs = [6,10]
+                , rsChange = [4]
+                , rsOutputs = [1,11]
+                })
             (CoinSelectionFixture
                 { maxNumOfInputs = 2
                 , utxoInputs = [1,2,10,6,5]

--- a/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.CoinSelection.Algorithm.LargestFirstSpec
-    ( spec
+    ( isValidLargestFirstError
+    , spec
     ) where
 
 import Prelude
@@ -236,3 +238,17 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
         $ selectCoins largestFirst
         $ CoinSelectionParameters utxo txOuts selectionLimit
     selectionLimit = CoinSelectionLimit $ const 100
+
+--------------------------------------------------------------------------------
+-- Utilities
+--------------------------------------------------------------------------------
+
+-- Returns true if (and only if) the given error value is one that can be
+-- thrown by the Largest-First algorithm.
+--
+isValidLargestFirstError :: CoinSelectionError -> Bool
+isValidLargestFirstError = \case
+    InputLimitExceeded     _ -> True
+    InputValueInsufficient _ -> True
+    InputCountInsufficient _ -> False
+    InputsExhausted        _ -> False

--- a/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
@@ -55,7 +55,8 @@ spec :: Spec
 spec = do
     describe "Coin selection: largest-first algorithm: unit tests" $ do
 
-        coinSelectionUnitTest largestFirst ""
+        coinSelectionUnitTest largestFirst
+            "Expect success: case #1"
             (Right $ CoinSelectionTestResult
                 { rsInputs = [17]
                 , rsChange = []
@@ -67,7 +68,8 @@ spec = do
                 , txOutputs = [17]
                 })
 
-        coinSelectionUnitTest largestFirst ""
+        coinSelectionUnitTest largestFirst
+            "Expect success: case #2"
             (Right $ CoinSelectionTestResult
                 { rsInputs = [17]
                 , rsChange = [16]
@@ -79,7 +81,8 @@ spec = do
                 , txOutputs = [1]
                 })
 
-        coinSelectionUnitTest largestFirst ""
+        coinSelectionUnitTest largestFirst
+            "Expect success: case #3"
             (Right $ CoinSelectionTestResult
                 { rsInputs = [12, 17]
                 , rsChange = [11]
@@ -91,7 +94,8 @@ spec = do
                 , txOutputs = [18]
                 })
 
-        coinSelectionUnitTest largestFirst ""
+        coinSelectionUnitTest largestFirst
+            "Expect success: case #4"
             (Right $ CoinSelectionTestResult
                 { rsInputs = [10, 12, 17]
                 , rsChange = [9]
@@ -103,7 +107,8 @@ spec = do
                 , txOutputs = [30]
                 })
 
-        coinSelectionUnitTest largestFirst ""
+        coinSelectionUnitTest largestFirst
+            "Expect success: case #5"
             (Right $ CoinSelectionTestResult
                 { rsInputs = [6,10]
                 , rsChange = [4]
@@ -116,27 +121,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "UTxO balance not sufficient"
-            (Left $ InputValueInsufficient $ InputValueInsufficientError
-                (unsafeCoin @Int 39) (unsafeCoin @Int 40))
-            (CoinSelectionFixture
-                { maxNumOfInputs = 100
-                , utxoInputs = [12,10,17]
-                , txOutputs = [40]
-                })
-
-        coinSelectionUnitTest largestFirst
-            "UTxO balance not sufficient"
-            (Left $ InputValueInsufficient $ InputValueInsufficientError
-                (unsafeCoin @Int 39) (unsafeCoin @Int 43))
-            (CoinSelectionFixture
-                { maxNumOfInputs = 100
-                , utxoInputs = [12,10,17]
-                , txOutputs = [40,1,1,1]
-                })
-
-        coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient"
+            "Expect success: case #6"
             (Right $ CoinSelectionTestResult
                 { rsInputs = [12,17,20]
                 , rsChange = [6]
@@ -149,7 +134,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient"
+            "Expect success: case #7"
             (Right $ CoinSelectionTestResult
                 { rsInputs = [12,17,20]
                 , rsChange = [8]
@@ -162,7 +147,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient"
+            "Expect success: case #8"
             (Right $ CoinSelectionTestResult
                 { rsInputs = [10,20,20]
                 , rsChange = [3]
@@ -175,25 +160,7 @@ spec = do
                 })
 
         coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient, but maximum input count exceeded"
-            (Left $ InputLimitExceeded $ InputLimitExceededError 9)
-            (CoinSelectionFixture
-                { maxNumOfInputs = 9
-                , utxoInputs = replicate 100 1
-                , txOutputs = replicate 100 1
-                })
-
-        coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient, but maximum input count exceeded"
-            (Left $ InputLimitExceeded $ InputLimitExceededError 9)
-            (CoinSelectionFixture
-                { maxNumOfInputs = 9
-                , utxoInputs = replicate 100 1
-                , txOutputs = replicate 10 10
-                })
-
-        coinSelectionUnitTest largestFirst
-            "UTxO balance sufficient"
+            "Expect success: case #9"
             (Right $ CoinSelectionTestResult
                 { rsInputs = [6,10]
                 , rsChange = [4]
@@ -203,6 +170,35 @@ spec = do
                 { maxNumOfInputs = 2
                 , utxoInputs = [1,2,10,6,5]
                 , txOutputs = [11, 1]
+                })
+
+        coinSelectionUnitTest largestFirst
+            "UTxO balance not sufficient: case #1"
+            (Left $ InputValueInsufficient $ InputValueInsufficientError
+                (unsafeCoin @Int 39) (unsafeCoin @Int 40))
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [12,10,17]
+                , txOutputs = [40]
+                })
+
+        coinSelectionUnitTest largestFirst
+            "UTxO balance not sufficient: case #2"
+            (Left $ InputValueInsufficient $ InputValueInsufficientError
+                (unsafeCoin @Int 39) (unsafeCoin @Int 43))
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [12,10,17]
+                , txOutputs = [40,1,1,1]
+                })
+
+        coinSelectionUnitTest largestFirst
+            "UTxO balance sufficient, but maximum input count exceeded"
+            (Left $ InputLimitExceeded $ InputLimitExceededError 9)
+            (CoinSelectionFixture
+                { maxNumOfInputs = 9
+                , utxoInputs = replicate 100 1
+                , txOutputs = replicate 100 1
                 })
 
     describe "Coin selection: largest-first algorithm: properties" $ do

--- a/src/test/Cardano/CoinSelection/Algorithm/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/RandomImproveSpec.hs
@@ -242,7 +242,7 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst params
     selectionLimit = CoinSelectionLimit $ const 100
-    params = CoinSelectionParameters txOuts utxo selectionLimit
+    params = CoinSelectionParameters utxo txOuts selectionLimit
 
 propErrors
     :: (Ord i, Ord o)
@@ -261,4 +261,4 @@ propErrors drg (CoinSelProp utxo txOuts) = do
     selection2 = runIdentity $ runExceptT $
         selectCoins largestFirst params
     selectionLimit = CoinSelectionLimit $ const 1
-    params = CoinSelectionParameters txOuts utxo selectionLimit
+    params = CoinSelectionParameters utxo txOuts selectionLimit

--- a/src/test/Cardano/CoinSelection/Algorithm/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/RandomImproveSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -23,6 +24,8 @@ import Cardano.CoinSelection
     )
 import Cardano.CoinSelection.Algorithm.LargestFirst
     ( largestFirst )
+import Cardano.CoinSelection.Algorithm.LargestFirstSpec
+    ( isValidLargestFirstError )
 import Cardano.CoinSelection.Algorithm.RandomImprove
     ( randomImprove )
 import Cardano.CoinSelectionSpec
@@ -40,13 +43,13 @@ import Crypto.Random
 import Crypto.Random.Types
     ( withDRG )
 import Data.Either
-    ( isLeft, isRight )
+    ( isRight )
 import Data.Functor.Identity
     ( Identity (..) )
 import Test.Hspec
-    ( Spec, before, describe, it, shouldSatisfy )
+    ( Spec, before, describe, it, shouldBe, shouldSatisfy )
 import Test.QuickCheck
-    ( Property, property, (===), (==>) )
+    ( Property, counterexample, property, (==>) )
 
 import qualified Data.List as L
 
@@ -245,20 +248,52 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
     params = CoinSelectionParameters utxo txOuts selectionLimit
 
 propErrors
-    :: (Ord i, Ord o)
+    :: (Ord i, Ord o, Show i, Show o)
     => SystemDRG
     -> CoinSelProp i o
     -> Property
-propErrors drg (CoinSelProp utxo txOuts) = do
-    isLeft selection1 && isLeft selection2 ==>
-        let (Left s1, Left s2) = (selection1, selection2)
-        in prop (s1, s2)
+propErrors drg (CoinSelProp utxo txOuts) =
+    case resultRandomImprove of
+        Right _ ->
+            -- Largest-First should always succeed if Random-Improve succeeds.
+            counterexample "case: Success"
+                $ property
+                $ resultLargestFirst `shouldSatisfy` isRight
+        Left (InputValueInsufficient _) ->
+            -- Largest-First should fail in exactly the same way when the total
+            -- value available is insufficient.
+            counterexample "case: InputValueInsufficient"
+                $ property
+                $ resultLargestFirst `shouldBe` resultRandomImprove
+        Left (InputCountInsufficient _) ->
+            -- Largest-First can still succeed in this case, so just check for
+            -- a valid result.
+            counterexample "case: InputCountInsufficient"
+                $ property
+                $ resultLargestFirst `shouldSatisfy` isValidLargestFirstResult
+        Left (InputsExhausted _) ->
+            -- Largest-First can still succeed in this case, so just check for
+            -- a valid result.
+            counterexample "case: InputsExhausted"
+                $ property
+                $ resultLargestFirst `shouldSatisfy` isValidLargestFirstResult
+        Left (InputLimitExceeded _) ->
+            -- Largest-First can still succeed in this case, so just check for
+            -- a valid result.
+            counterexample "case: InputLimitExceeded"
+                $ property
+                $ resultLargestFirst `shouldSatisfy` isValidLargestFirstResult
   where
-    prop (err1, err2) =
-        err1 === err2
-    (selection1,_) = withDRG drg $
+    isValidLargestFirstResult = \case
+        Right _ ->
+            -- We assume that this is a valid result, based on the assumption
+            -- that test coverage for Largest-First is sufficient.
+            True
+        Left x ->
+            isValidLargestFirstError x
+    resultRandomImprove = fst $ withDRG drg $
         runExceptT $ selectCoins randomImprove params
-    selection2 = runIdentity $ runExceptT $
+    resultLargestFirst = runIdentity $ runExceptT $
         selectCoins largestFirst params
     selectionLimit = CoinSelectionLimit $ const 1
     params = CoinSelectionParameters utxo txOuts selectionLimit

--- a/src/test/Cardano/CoinSelection/Algorithm/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/RandomImproveSpec.hs
@@ -29,7 +29,7 @@ import Cardano.CoinSelection.Algorithm.LargestFirstSpec
 import Cardano.CoinSelection.Algorithm.RandomImprove
     ( randomImprove )
 import Cardano.CoinSelectionSpec
-    ( CoinSelProp (..)
+    ( CoinSelectionData (..)
     , CoinSelectionFixture (..)
     , CoinSelectionTestResult (..)
     , coinSelectionUnitTest
@@ -230,9 +230,9 @@ spec = do
 propFragmentation
     :: (Ord i, Ord o)
     => SystemDRG
-    -> CoinSelProp i o
+    -> CoinSelectionData i o
     -> Property
-propFragmentation drg (CoinSelProp utxo txOuts) = do
+propFragmentation drg (CoinSelectionData utxo txOuts) = do
     isRight selection1 && isRight selection2 ==>
         let Right (CoinSelectionResult s1 _) = selection1 in
         let Right (CoinSelectionResult s2 _) = selection2 in
@@ -250,9 +250,9 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
 propErrors
     :: (Ord i, Ord o, Show i, Show o)
     => SystemDRG
-    -> CoinSelProp i o
+    -> CoinSelectionData i o
     -> Property
-propErrors drg (CoinSelProp utxo txOuts) =
+propErrors drg (CoinSelectionData utxo txOuts) =
     case resultRandomImprove of
         Right _ ->
             -- Largest-First should always succeed if Random-Improve succeeds.

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -15,7 +15,7 @@ module Cardano.CoinSelectionSpec
     -- * Export used to test various coin selection implementations
     , CoinSelectionFixture (..)
     , CoinSelectionTestResult (..)
-    , CoinSelProp (..)
+    , CoinSelectionData (..)
     , coinSelectionUnitTest
     ) where
 
@@ -284,17 +284,17 @@ prop_coinSelection_mappendPreservesTotalValue s1 s2 = property $ do
 -- Coin Selection - Unit Tests
 --------------------------------------------------------------------------------
 
--- | Data for running
-data CoinSelProp i o = CoinSelProp
-    { csUtxO :: CoinMap i
-        -- ^ Available UTxO for the selection
-    , csOuts :: CoinMap o
-        -- ^ Requested outputs for the payment
+-- | Data for coin selection properties.
+data CoinSelectionData i o = CoinSelectionData
+    { csdInputsAvailable
+        :: CoinMap i
+    , csdOutputsRequested
+        :: CoinMap o
     } deriving Show
 
-instance (Buildable i, Buildable o) => Buildable (CoinSelProp i o) where
-    build (CoinSelProp utxo outs) = mempty
-        <> nameF "utxo" (blockListF $ coinMapToList utxo)
+instance (Buildable i, Buildable o) => Buildable (CoinSelectionData i o) where
+    build (CoinSelectionData inps outs) = mempty
+        <> nameF "inps" (blockListF $ coinMapToList inps)
         <> nameF "outs" (blockListF $ coinMapToList outs)
 
 -- | A fixture for testing the coin selection
@@ -396,12 +396,12 @@ instance Arbitrary a => Arbitrary (NonEmpty a) where
         NE.fromList <$> vectorOf n arbitrary
 
 instance (Arbitrary i, Arbitrary o, Ord i, Ord o) =>
-    Arbitrary (CoinSelProp i o)
+    Arbitrary (CoinSelectionData i o)
   where
-    shrink (CoinSelProp utxo outs) = uncurry CoinSelProp <$> zip
-        (shrink utxo)
+    shrink (CoinSelectionData inps outs) = uncurry CoinSelectionData <$> zip
+        (shrink inps)
         (coinMapFromList <$> filter (not . null) (shrink (coinMapToList outs)))
-    arbitrary = CoinSelProp
+    arbitrary = CoinSelectionData
         <$> (coinMapFromList . getNonEmpty <$> arbitrary)
         <*> (coinMapFromList . getNonEmpty <$> arbitrary)
 


### PR DESCRIPTION
## Related Issue

#39 

## Summary

This PR changes the reference implementation of the `Largest-First` coin selection algorithm to match the [specification](https://github.com/jonathanknowles/CIPs/blob/CIP-JonathanKnowles-CoinSelectionAlgorithms/CIP-JonathanKnowles-CoinSelectionAlgorithms/CIP-JonathanKnowles-CoinSelectionAlgorithms.md#largest-first).

After applying this PR, the algorithm should always be successful at paying for a given set of outputs of total value **_v_** provided that the total value **_u_** of available inputs satisfies **_u_** ≥ **_v_**. (Unless the maximum input count has been exceeded.)

### Old implementation (before applying this PR)
    
Rather than considering the total collective value of all outputs when attempting to find a selection of inputs, the old implementation considered each output independently, and for each output, attempted to find a selection of inputs to cover just that output.
    
This created an unnecessary cardinality restriction, namely that a single unique input could only be used to pay for at most one unique output, which meant that any set of **_n_** outputs could only be paid for if there were at least **_n_** inputs available. Under this restriction, the algorithm could fail _even if_ the total value of inputs was sufficient to cover the required outputs.
    
### New implementation (after applying this PR)
    
The updated algorithm now considers the _total_ value of all outputs collectively, rather than considering them individually.
    
Under this relaxed scheme, it will always be possible to pay for a given set of outputs of total value **_v_** if the total value **_u_** of available inputs satisfies **_u_** ≥ **_v_**. (Unless the maximum input count has been exceeded.)