### PR TITLE
Prevent the migration algorithm from creating money.

### DIFF
--- a/src/library/Cardano/CoinSelection/Algorithm/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Algorithm/Migration.hs
@@ -42,6 +42,7 @@ import Cardano.CoinSelection.Fee
     , FeeBalancingPolicy (..)
     , FeeEstimator (..)
     , FeeOptions (..)
+    , isDust
     )
 import Control.Monad.Trans.State
     ( State, evalState, get, put )
@@ -124,7 +125,7 @@ selectCoins options (BatchSize batchSize) utxo =
         threshold = unDustThreshold dustThreshold
         noDust :: Coin -> Maybe Coin
         noDust c
-            | c <= threshold = Nothing
+            | isDust dustThreshold c = Nothing
             | otherwise = Just c
 
     -- | Attempt to balance the coin selection by reducing or increasing the

--- a/src/library/Cardano/CoinSelection/Algorithm/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Algorithm/Migration.hs
@@ -49,7 +49,7 @@ import Control.Monad.Trans.State
 import Data.List.NonEmpty
     ( NonEmpty ((:|)) )
 import Data.Maybe
-    ( fromMaybe, mapMaybe )
+    ( fromMaybe )
 import Data.Word
     ( Word16 )
 import GHC.Generics
@@ -119,13 +119,13 @@ selectCoins options (BatchSize batchSize) utxo =
         inputs = coinMapFromList inputEntries
         outputs = mempty
         change =
-            let chgs = mapMaybe (noDust . entryValue) inputEntries
-            in if null chgs then [C.succ threshold] else chgs
+            if null nonDustInputCoins
+            then [C.succ threshold]
+            else nonDustInputCoins
         threshold = unDustThreshold dustThreshold
-        noDust :: Coin -> Maybe Coin
-        noDust c
-            | isDust dustThreshold c = Nothing
-            | otherwise = Just c
+        nonDustInputCoins = filter
+            (not . isDust dustThreshold)
+            (entryValue <$> inputEntries)
 
     -- | Attempt to balance the coin selection by reducing or increasing the
     -- change values based on the computed fees.

--- a/src/library/Cardano/CoinSelection/Algorithm/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Algorithm/Migration.hs
@@ -114,14 +114,13 @@ selectCoins options (BatchSize batchSize) utxo =
     -- Note that the selection may look a bit weird at first sight as it has
     -- no outputs (we are paying everything to ourselves!).
     mkCoinSelection :: [CoinMapEntry i] -> CoinSelection i o
-    mkCoinSelection inps = CoinSelection
-        { inputs = coinMapFromList inps
-        , outputs = mempty
-        , change =
-            let chgs = mapMaybe (noDust . entryValue) inps
-            in if null chgs then [C.succ threshold] else chgs
-        }
+    mkCoinSelection inputEntries = CoinSelection {inputs, outputs, change}
       where
+        inputs = coinMapFromList inputEntries
+        outputs = mempty
+        change =
+            let chgs = mapMaybe (noDust . entryValue) inputEntries
+            in if null chgs then [C.succ threshold] else chgs
         threshold = unDustThreshold dustThreshold
         noDust :: Coin -> Maybe Coin
         noDust c

--- a/src/library/Cardano/CoinSelection/Algorithm/Migration.hs
+++ b/src/library/Cardano/CoinSelection/Algorithm/Migration.hs
@@ -118,13 +118,13 @@ selectCoins options (BatchSize batchSize) utxo =
         , outputs = mempty
         , change =
             let chgs = mapMaybe (noDust . entryValue) inps
-            in if null chgs then [threshold] else chgs
+            in if null chgs then [C.succ threshold] else chgs
         }
       where
         threshold = unDustThreshold dustThreshold
         noDust :: Coin -> Maybe Coin
         noDust c
-            | c < threshold = Nothing
+            | c <= threshold = Nothing
             | otherwise = Just c
 
     -- | Attempt to balance the coin selection by reducing or increasing the

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -119,6 +119,17 @@ newtype DustThreshold = DustThreshold { unDustThreshold :: Coin }
     deriving stock (Eq, Generic, Ord)
     deriving Show via (Quiet DustThreshold)
 
+-- | Returns 'True' if and only if the given 'Coin' is a __dust coin__
+--   according to the given 'DustThreshold'.
+--
+-- A coin is considered to be a dust coin if it is /less than or equal to/
+-- the threshold.
+--
+-- See 'DustThreshold'.
+--
+isDust :: DustThreshold -> Coin -> Bool
+isDust (DustThreshold dt) c = c <= dt
+
 -- | Provides a function capable of __estimating__ the transaction fee required
 --   for a given coin selection, according to the rules of a particular
 --   blockchain.

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -629,10 +629,10 @@ distributeFee (Fee feeTotal) coinsUnsafe =
 -- >>> all (/= Coin 0) (coalesceDust threshold coins)
 --
 coalesceDust :: DustThreshold -> NonEmpty Coin -> [Coin]
-coalesceDust (DustThreshold threshold) coins =
+coalesceDust threshold coins =
     splitCoin valueToDistribute coinsToKeep
   where
-    (coinsToKeep, coinsToRemove) = NE.partition (> threshold) coins
+    (coinsToRemove, coinsToKeep) = NE.partition (isDust threshold) coins
     valueToDistribute = F.fold coinsToRemove
 
 -- Splits up the given coin of value __@v@__, distributing its value over the

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -31,6 +31,7 @@ module Cardano.CoinSelection.Fee
 
       -- * Dust Processing
     , DustThreshold (..)
+    , isDust
     , coalesceDust
 
       -- # Internal Functions

--- a/src/test/Cardano/CoinSelection/Algorithm/MigrationSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/MigrationSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -117,27 +118,27 @@ spec = do
 
     describe "selectCoins properties" $ do
         it "No coin selection has outputs" $
-            property $ withMaxSuccess 10000 $ prop_onlyChangeOutputs
+            property $ withMaxSuccess 10_000 $ prop_onlyChangeOutputs
                 @(Wrapped TxIn) @Address
 
         it "Every coin in the selection change > dust threshold" $
-            property $ withMaxSuccess 10000 $ prop_allAboveThreshold
+            property $ withMaxSuccess 10_000 $ prop_allAboveThreshold
                 @(Wrapped TxIn) @Address
 
         it "Total input UTxO value >= sum of selection change coins" $
-            property $ withMaxSuccess 10000 $ prop_inputsGreaterThanOutputs
+            property $ withMaxSuccess 10_000 $ prop_inputsGreaterThanOutputs
                 @(Wrapped TxIn) @Address
 
         it "Every selection input is unique" $
-            property $ withMaxSuccess 10000 $ prop_inputsAreUnique
+            property $ withMaxSuccess 10_000 $ prop_inputsAreUnique
                 @(Wrapped TxIn) @Address
 
         it "Every selection input is a member of the UTxO" $
-            property $ withMaxSuccess 10000 $ prop_inputsStillInUTxO
+            property $ withMaxSuccess 10_000 $ prop_inputsStillInUTxO
                 @(Wrapped TxIn) @Address
 
         it "Every coin selection is well-balanced" $
-            property $ withMaxSuccess 10000 $ prop_wellBalanced
+            property $ withMaxSuccess 10_000 $ prop_wellBalanced
                 @(Wrapped TxIn) @Address
 
     describe "selectCoins regressions" $ do


### PR DESCRIPTION
## Related Issue

#74 

## Summary

The migration algorithm should satisfy the following property:

> total value of all inputs ≥ sum of selection change coins

Recent [test failures](https://github.com/input-output-hk/cardano-coin-selection/issues/74#issuecomment-626457103) have showed that the existing implementation occasionally failed to respect this property, in very rare situations.

In particular, supplying a coin selection where the total value of all inputs (in a given batch) is _less than_ the minimum value of a non-dust coin will reliably produce a set of change coins whose total value is greater than the total value of all inputs. (See #74 for examples of test failures.)

This PR fixes the above issue by adding a guard to the `mkCoinSelection` function, preventing it from creating an initial change coin if that change coin would be higher than the total value of all inputs.

Demonstration (with **one million** tests per property):
```hs
  selectCoins properties
    No coin selection has outputs
      +++ OK, passed 1000000 tests.  
    Every coin in the selection change > dust threshold
      +++ OK, passed 1000000 tests.  
    Total input UTxO value >= sum of selection change coins
      +++ OK, passed 1000000 tests.
    Every selection input is unique   
      +++ OK, passed 1000000 tests.
    Every selection input is a member of the UTxO
      +++ OK, passed 1000000 tests.
    Every coin selection is well-balanced
      +++ OK, passed 1000000 tests.
```

## Other Changes

This PR also makes the following changes:
- [x] Corrects a number of inconsistent dust inequality checks in the code. The library currently defines the dust threshold as the _maximum size of a dust coin_, rather than the minimum size of a non-dust coin. (By defining it in this way, we can arrange that zero-valued coins are always eliminated by the dust elimination mechanism, as it is not possible to specify a dust threshold lower than zero.)
- [x] Adds a function `isDust` to provide a uniform way to determine whether or not a given coin is a dust coin, and uses it to replace a number of inequality checks.
