### PR TITLE
Add `@since 1.0.1` tag to `isDust`.

### DIFF
--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -128,6 +128,7 @@ newtype DustThreshold = DustThreshold { unDustThreshold :: Coin }
 --
 -- See 'DustThreshold'.
 --
+-- @since 1.0.1
 isDust :: DustThreshold -> Coin -> Bool
 isDust (DustThreshold dt) c = c <= dt
 


### PR DESCRIPTION
## Related Issue

#78 

## Summary

This PR adds the `@since 1.0.1` tag to function `isDust`.