### PR TITLE
Add Specification Properties.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -51,6 +51,9 @@
 - ignore: {name: "Redundant do"} # Just an annoying hlint built-in, GHC may remove redundant do if he wants
 - ignore: {name: "Monoid law, left identity"} # Using 'mempty' can be useful to vertically-align elements
 - ignore: {name: "Use ?~"} # It's actually much clearer to do (.~ Just ...) than having to load yet-another-lens-operator
+- ignore: {name: "Use camelCase"}    # Sometimes useful in test code.
+- ignore: {name: "Redundant lambda"} # Sometimes useful in test code.
+- ignore: {name: "Collapse lambdas"} # Sometimes useful in test code.
 
 # Add custom hints for this project
 #

--- a/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
@@ -33,6 +33,7 @@ import Cardano.CoinSelectionSpec
     ( CoinSelectionData (..)
     , CoinSelectionFixture (..)
     , CoinSelectionTestResult (..)
+    , coinSelectionAlgorithmGeneralProperties
     , coinSelectionUnitTest
     )
 import Cardano.Test.Utilities
@@ -276,6 +277,9 @@ spec = do
                 $ property
                 $ withMaxSuccess 10_000
                 $ propChangeCorrect @Int @Int)
+
+    coinSelectionAlgorithmGeneralProperties @Int @Int
+        largestFirst "Largest-First"
 
 --------------------------------------------------------------------------------
 -- Properties

--- a/src/test/Cardano/CoinSelection/Algorithm/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/RandomImproveSpec.hs
@@ -32,6 +32,7 @@ import Cardano.CoinSelectionSpec
     ( CoinSelectionData (..)
     , CoinSelectionFixture (..)
     , CoinSelectionTestResult (..)
+    , coinSelectionAlgorithmGeneralProperties
     , coinSelectionUnitTest
     )
 import Cardano.Test.Utilities
@@ -222,6 +223,9 @@ spec = do
             it "forall (UTxO, NonEmpty TxOut), running algorithm gives the \
                 \same errors as LargestFirst algorithm"
                 (property . propErrors @TxIn @Address)
+
+    coinSelectionAlgorithmGeneralProperties @Int @Int
+        randomImprove "Random-Improve"
 
 --------------------------------------------------------------------------------
 -- Properties

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -140,7 +140,7 @@ spec = do
     lowerConfidence = Confidence (10^(6 :: Integer)) 0.75
 
 --------------------------------------------------------------------------------
--- Properties
+-- Coin Map Properties
 --------------------------------------------------------------------------------
 
 prop_CoinMap_coverage
@@ -261,6 +261,10 @@ prop_coinMapToList_orderDeterministic u = monadicIO $ QC.run $ do
     return $
         cover 10 (list0 /= list1) "shuffled" $
         list0 == coinMapToList (coinMapFromList list1)
+
+--------------------------------------------------------------------------------
+-- Coin Selection Properties
+--------------------------------------------------------------------------------
 
 prop_coinSelection_mappendPreservesKeys
     :: (Ord i, Ord o, Show i, Show o)

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -170,6 +170,10 @@ coinSelectionAlgorithmGeneralProperties algorithm algorithmName =
             property $
             prop_algorithm_inputsAvailable_inputsRemaining algorithm
 
+        it "inputsSelected ⋂ inputsRemaining = ∅" $
+            property $
+            prop_algorithm_inputsSelected_inputsRemaining algorithm
+
 --------------------------------------------------------------------------------
 -- Coin Map Properties
 --------------------------------------------------------------------------------
@@ -384,6 +388,17 @@ prop_algorithm_inputsAvailable_inputsRemaining algorithm csd =
             inputsRemaining `shouldSatisfy`
                 (`isSubmapOf` csdInputsAvailable csd)
 
+prop_algorithm_inputsSelected_inputsRemaining
+    :: (Ord i, Show i)
+    => CoinSelectionAlgorithm i o IO
+    -> CoinSelectionData i o
+    -> Property
+prop_algorithm_inputsSelected_inputsRemaining algorithm csd =
+    prop_algorithm algorithm csd $
+        \(CoinSelectionResult (CoinSelection selected _ _) remaining) -> do
+            (selected `intersection` remaining)
+                `shouldBe` mempty
+
 prop_algorithm
     :: CoinSelectionAlgorithm i o IO
     -> CoinSelectionData i o
@@ -405,6 +420,9 @@ prop_algorithm algorithm csd verifyExpectation =
 
 isSubmapOf :: Ord k => CoinMap k -> CoinMap k -> Bool
 isSubmapOf (CoinMap a) (CoinMap b) = a `Map.isSubmapOf` b
+
+intersection :: Ord k => CoinMap k -> CoinMap k -> CoinMap k
+intersection (CoinMap a) (CoinMap b) = CoinMap $ a `Map.intersection` b
 
 --------------------------------------------------------------------------------
 -- Coin Selection - Unit Tests

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -154,6 +154,10 @@ coinSelectionAlgorithmGeneralProperties algorithm algorithmName =
 
     describe ("General properties for " <> algorithmName) $ do
 
+        it "value inputsAvailable ≥ value outputsRequested" $
+            property $
+            prop_algorithm_inputsAvailable_outputsRequested algorithm
+
         it "outputsSelected = outputsRequested" $
             property $
             prop_algorithm_outputsSelected_outputsRequested algorithm
@@ -330,6 +334,15 @@ prop_CoinSelectionData_coverage (CoinSelectionData inps outs) = property
 --------------------------------------------------------------------------------
 -- Coin Selection Algorithm Properties
 --------------------------------------------------------------------------------
+
+prop_algorithm_inputsAvailable_outputsRequested
+    :: CoinSelectionAlgorithm i o IO
+    -> CoinSelectionData i o
+    -> Property
+prop_algorithm_inputsAvailable_outputsRequested algorithm csd =
+    prop_algorithm algorithm csd $ const $
+        coinMapValue (csdInputsAvailable csd) `shouldSatisfy`
+            (>= coinMapValue (csdOutputsRequested csd))
 
 prop_algorithm_outputsSelected_outputsRequested
     :: (Ord o, Show o)

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -174,6 +174,11 @@ coinSelectionAlgorithmGeneralProperties algorithm algorithmName =
             property $
             prop_algorithm_inputsSelected_inputsRemaining algorithm
 
+        it "inputsSelected ⋃ inputsRemaining = inputsAvailable" $
+            property $
+            prop_algorithm_inputsSelected_inputsRemaining_inputsAvailable
+            algorithm
+
 --------------------------------------------------------------------------------
 -- Coin Map Properties
 --------------------------------------------------------------------------------
@@ -399,6 +404,19 @@ prop_algorithm_inputsSelected_inputsRemaining algorithm csd =
             (selected `intersection` remaining)
                 `shouldBe` mempty
 
+prop_algorithm_inputsSelected_inputsRemaining_inputsAvailable
+    :: (Ord i, Show i)
+    => CoinSelectionAlgorithm i o IO
+    -> CoinSelectionData i o
+    -> Property
+prop_algorithm_inputsSelected_inputsRemaining_inputsAvailable algorithm csd =
+    prop_algorithm algorithm csd $
+        \(CoinSelectionResult (CoinSelection selected _ _) remaining) -> do
+            (selected `union` remaining)
+                `shouldBe` available
+  where
+    available = csdInputsAvailable csd
+
 prop_algorithm
     :: CoinSelectionAlgorithm i o IO
     -> CoinSelectionData i o
@@ -423,6 +441,9 @@ isSubmapOf (CoinMap a) (CoinMap b) = a `Map.isSubmapOf` b
 
 intersection :: Ord k => CoinMap k -> CoinMap k -> CoinMap k
 intersection (CoinMap a) (CoinMap b) = CoinMap $ a `Map.intersection` b
+
+union :: Ord k => CoinMap k -> CoinMap k -> CoinMap k
+union = (<>)
 
 --------------------------------------------------------------------------------
 -- Coin Selection - Unit Tests

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -179,6 +179,12 @@ coinSelectionAlgorithmGeneralProperties algorithm algorithmName =
             prop_algorithm_inputsSelected_inputsRemaining_inputsAvailable
             algorithm
 
+        it "value inputsSelected =\
+            \ value outputsSelected + value changeGenerated" $
+            property $
+            prop_algorithm_inputsSelected_outputsSelected_changeGenerated
+            algorithm
+
 --------------------------------------------------------------------------------
 -- Coin Map Properties
 --------------------------------------------------------------------------------
@@ -416,6 +422,17 @@ prop_algorithm_inputsSelected_inputsRemaining_inputsAvailable algorithm csd =
                 `shouldBe` available
   where
     available = csdInputsAvailable csd
+
+prop_algorithm_inputsSelected_outputsSelected_changeGenerated
+    :: CoinSelectionAlgorithm i o IO
+    -> CoinSelectionData i o
+    -> Property
+prop_algorithm_inputsSelected_outputsSelected_changeGenerated algorithm csd =
+    prop_algorithm algorithm csd $
+        \(CoinSelectionResult (CoinSelection {inputs, outputs, change}) _) ->
+            coinMapValue inputs
+                `shouldBe`
+                (coinMapValue outputs `C.add` mconcat change)
 
 prop_algorithm
     :: CoinSelectionAlgorithm i o IO

--- a/src/test/Cardano/CoinSelectionSpec.hs
+++ b/src/test/Cardano/CoinSelectionSpec.hs
@@ -162,6 +162,10 @@ coinSelectionAlgorithmGeneralProperties algorithm algorithmName =
             property $
             prop_algorithm_outputsSelected_outputsRequested algorithm
 
+        it "inputsSelected ⊆ inputsAvailable" $
+            property $
+            prop_algorithm_inputsAvailable_inputsSelected algorithm
+
 --------------------------------------------------------------------------------
 -- Coin Map Properties
 --------------------------------------------------------------------------------
@@ -354,6 +358,17 @@ prop_algorithm_outputsSelected_outputsRequested algorithm csd =
         \(CoinSelection _ outputsSelected _) ->
             outputsSelected `shouldBe` csdOutputsRequested csd
 
+prop_algorithm_inputsAvailable_inputsSelected
+    :: (Ord i, Show i)
+    => CoinSelectionAlgorithm i o IO
+    -> CoinSelectionData i o
+    -> Property
+prop_algorithm_inputsAvailable_inputsSelected algorithm csd =
+    prop_algorithm algorithm csd $
+        \(CoinSelection inputsSelected _ _) ->
+            inputsSelected `shouldSatisfy`
+                (`isSubmapOf` csdInputsAvailable csd)
+
 prop_algorithm
     :: CoinSelectionAlgorithm i o IO
     -> CoinSelectionData i o
@@ -372,6 +387,9 @@ prop_algorithm algorithm csd expectation =
         $ CoinSelectionParameters csdInputsAvailable csdOutputsRequested
         $ CoinSelectionLimit
         $ const $ fromIntegral $ F.length csdInputsAvailable
+
+isSubmapOf :: Ord k => CoinMap k -> CoinMap k -> Bool
+isSubmapOf (CoinMap a) (CoinMap b) = a `Map.isSubmapOf` b
 
 --------------------------------------------------------------------------------
 -- Coin Selection - Unit Tests


### PR DESCRIPTION
## Related Issue

#21 

## Summary

This PR adds missing tests for the following properties, as defined by the [coin selection specification](https://github.com/input-output-hk/cardano-coin-selection/issues/21):

- Pre-conditions:
    - [x] `value inputsAvailable ≥ value outputsRequested`
- Post-conditions:
    - [x] `outputsSelected = outputsRequested`
    - [x] `inputsSelected ⊆ inputsAvailable`
    - [x] `inputsRemaining ⊆ inputsAvailable`
    - [x] `inputsSelected ⋂ inputsRemaining = ∅`
    - [x] `inputsSelected ⋃ inputsRemaining = inputsAvailable`
    - [x] `value inputsSelected = value outputsSelected + value change`


This PR also checks that the above properties are satisfied by all algorithms that implement the `CoinSelectionAlgorithm` interface.