### PR TITLE
Retire wallet-specific types from the test suite.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -54,6 +54,7 @@
 - ignore: {name: "Use camelCase"}    # Sometimes useful in test code.
 - ignore: {name: "Redundant lambda"} # Sometimes useful in test code.
 - ignore: {name: "Collapse lambdas"} # Sometimes useful in test code.
+- ignore: {name: "Use section"} # Useful for aligning elements vertically.
 
 # Add custom hints for this project
 #

--- a/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/LargestFirstSpec.hs
@@ -37,7 +37,7 @@ import Cardano.CoinSelectionSpec
     , coinSelectionUnitTest
     )
 import Cardano.Test.Utilities
-    ( Address, TxIn, excluding, unsafeCoin )
+    ( InputId, OutputId, excluding, unsafeCoin )
 import Control.Monad
     ( unless )
 import Control.Monad.Trans.Except
@@ -265,20 +265,20 @@ spec = do
         it "forall (UTxO, NonEmpty TxOut), for all selected input, there's no \
             \bigger input in the UTxO that is not already in the selected \
             \inputs"
-            (property $ propInputDecreasingOrder @TxIn @Address)
+            (property $ propInputDecreasingOrder @InputId @OutputId)
 
         it "The algorithm selects just enough inputs and no more."
             (property
                 $ withMaxSuccess 10_000
-                $ propSelectionMinimal @Int @Int)
+                $ propSelectionMinimal @InputId @OutputId)
 
         it "The algorithm produces the correct set of change."
             (checkCoverage
                 $ property
                 $ withMaxSuccess 10_000
-                $ propChangeCorrect @Int @Int)
+                $ propChangeCorrect @InputId @OutputId)
 
-    coinSelectionAlgorithmGeneralProperties @Int @Int
+    coinSelectionAlgorithmGeneralProperties @InputId @OutputId
         largestFirst "Largest-First"
 
 --------------------------------------------------------------------------------

--- a/src/test/Cardano/CoinSelection/Algorithm/RandomImproveSpec.hs
+++ b/src/test/Cardano/CoinSelection/Algorithm/RandomImproveSpec.hs
@@ -36,7 +36,7 @@ import Cardano.CoinSelectionSpec
     , coinSelectionUnitTest
     )
 import Cardano.Test.Utilities
-    ( Address, TxIn, unsafeCoin )
+    ( InputId, OutputId, unsafeCoin )
 import Control.Monad.Trans.Except
     ( runExceptT )
 import Crypto.Random
@@ -219,12 +219,12 @@ spec = do
         describe "Coin selection properties : random algorithm" $ do
             it "forall (UTxO, NonEmpty TxOut), running algorithm gives not \
                 \less UTxO fragmentation than LargestFirst algorithm"
-                (property . propFragmentation @TxIn @Address)
+                (property . propFragmentation @InputId @OutputId)
             it "forall (UTxO, NonEmpty TxOut), running algorithm gives the \
                 \same errors as LargestFirst algorithm"
-                (property . propErrors @TxIn @Address)
+                (property . propErrors @InputId @OutputId)
 
-    coinSelectionAlgorithmGeneralProperties @Int @Int
+    coinSelectionAlgorithmGeneralProperties @InputId @OutputId
         randomImprove "Random-Improve"
 
 --------------------------------------------------------------------------------

--- a/src/test/Cardano/CoinSelection/TypesSpec.hs
+++ b/src/test/Cardano/CoinSelection/TypesSpec.hs
@@ -21,7 +21,6 @@ import Cardano.Test.Utilities
     , Hash (..)
     , ShowFmt (..)
     , TxIn (..)
-    , TxOut (..)
     , excluding
     , isSubsetOf
     , restrictedBy
@@ -234,12 +233,6 @@ instance Arbitrary Address where
 instance Arbitrary Coin where
     -- No Shrinking
     arbitrary = unsafeCoin @Int <$> choose (0, 3)
-
-instance Arbitrary TxOut where
-    -- No Shrinking
-    arbitrary = TxOut
-        <$> arbitrary
-        <*> arbitrary
 
 instance Arbitrary TxIn where
     -- No Shrinking

--- a/src/test/Cardano/Test/Utilities.hs
+++ b/src/test/Cardano/Test/Utilities.hs
@@ -30,7 +30,6 @@ module Cardano.Test.Utilities
 
     -- * Transactions
     , TxIn (..)
-    , TxOut (..)
 
     -- * UTxO Operations
     , excluding
@@ -199,23 +198,6 @@ instance Buildable TxIn where
         <> ordinalF (txinIx txin + 1)
         <> " "
         <> build (txinId txin)
-
-data TxOut = TxOut
-    { txoutAddress
-        :: !Address
-    , txoutCoin
-        :: !Coin
-    } deriving (Show, Generic, Eq, Ord)
-
-instance Buildable TxOut where
-    build txout = mempty
-        <> build (txoutCoin txout)
-        <> " @ "
-        <> prefixF 8 addrF
-        <> "..."
-        <> suffixF 8 addrF
-      where
-        addrF = build $ txoutAddress txout
 
 --------------------------------------------------------------------------------
 -- UTxO Operations


### PR DESCRIPTION
## Related Issue

#34 

## Summary

This PR retires the following wallet-specific types from the test suite:

- [x] `TxIn`
- [x] `TxOut`
- [x] `Address`
- [x] `Hash`

The following simpler types are introduced as replacements:

- [x] `InputId`
- [x] `OutputId`

Both of the above types are based on a common `UniqueId` type, which just wraps a `ByteString`.

## Motivation

Before this change, QuickCheck failures would often produce output similar to the following:
    
```hs
TxIn {txinId = Hash "\GS\STX.\t\CAN\STX*/\DC3'@@7$;)4\STX\DC2*@+\RS0/=-\SUB%\b\RS?", txinIx = 1}
```

As a single value, this is already pretty difficult to read. Test failures involving multiple such values can be almost unreadable!

By contrast, `Show` instances for `InputId` and `Output` produce output similar to:

```hs
InputId 1a2b3c4d
```