### PR TITLE
ci: git diff --no-pager

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,6 +26,6 @@ jobs:
             echo "No style errors detected."
         else
             echo "Style errors detected:"
-            git diff
+            git --no-pager diff
             exit 1
         fi


### PR DESCRIPTION
Hello :wave:
I was using configuration of CI in this repo as an inspiration about how to easily setup stylish-haskell and I noticed this problem.

commit:

Without this, git might enther the interactive mode
based on the size of the diff which will cause CI to hang
on this interactive output.

Documentation: https://git-scm.com/docs/git#Documentation/git.txt---no-pager