### PR TITLE
Revise type of internal function `coinMapRandomEntry`.

### DIFF
--- a/src/library/Cardano/CoinSelection.hs
+++ b/src/library/Cardano/CoinSelection.hs
@@ -388,12 +388,12 @@ newtype InputLimitExceededError =
 coinMapRandomEntry
     :: MonadRandom m
     => CoinMap a
-    -> m (Maybe (CoinMapEntry a), CoinMap a)
+    -> m (Maybe (CoinMapEntry a, CoinMap a))
 coinMapRandomEntry (CoinMap m)
     | Map.null m =
-        return (Nothing, CoinMap m)
-    | otherwise = do
+        return Nothing
+    | otherwise = Just <$> do
         ix <- fromEnum <$> generateBetween 0 (toEnum (Map.size m - 1))
         let entry = uncurry CoinMapEntry $ Map.elemAt ix m
         let remainder = CoinMap $ Map.deleteAt ix m
-        return (Just entry, remainder)
+        return (entry, remainder)

--- a/src/library/Cardano/CoinSelection/Fee.hs
+++ b/src/library/Cardano/CoinSelection/Fee.hs
@@ -63,6 +63,8 @@ import Control.Monad.Trans.State
     ( StateT (..), evalStateT )
 import Crypto.Random.Types
     ( MonadRandom )
+import Data.Bifunctor
+    ( first )
 import Data.Function
     ( (&) )
 import Data.List.NonEmpty
@@ -399,12 +401,14 @@ coverRemainingFee (Fee fee) = go [] where
             return acc
         | otherwise = do
             -- We ignore the size of the fee, and just pick randomly
-            StateT (lift . coinMapRandomEntry) >>= \case
+            StateT (lift . selectRandomEntry) >>= \case
                 Just entry ->
                     go (entry : acc)
                 Nothing ->
                     lift $ throwE $ CannotCoverFee $ Fee $
                         fee `C.distance` (sumEntries acc)
+    selectRandomEntry m =
+        maybe (Nothing, m) (first Just) <$> coinMapRandomEntry m
 
 -- Pays for the given fee by subtracting it from the given list of change
 -- outputs, so that each change output is reduced by a portion of the fee


### PR DESCRIPTION
## Summary

This PR:

1. Updates the return type of `coinMapRandomEntry` to return `Nothing` when no entry is available, matching the documentation.

2. Removes the now-rendundant `utxoPickRandomT` function.